### PR TITLE
feat(explorer): add interactive results explorer (Issue #10)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,9 +10,13 @@
         "@ai-sdk/google-vertex": "^3.0.74",
         "@ai-sdk/openai": "^2.0.88",
         "@anthropic-ai/vertex-sdk": "^0.14.0",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
         "ai": "^5.0.44",
         "bun": "^1.3.5",
         "dedent": "^1.7.0",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
         "zod": "^4.1.9",
       },
       "devDependencies": {
@@ -93,7 +97,9 @@
 
     "@types/node": ["@types/node@24.5.1", "", { "dependencies": { "undici-types": "~7.12.0" } }, "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q=="],
 
-    "@types/react": ["@types/react@19.1.13", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ=="],
+    "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
@@ -109,7 +115,7 @@
 
     "bun-types": ["bun-types@1.2.22", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-hwaAu8tct/Zn6Zft4U9BsZcXkYomzpHJX28ofvx7k0Zz2HNz54n1n+tDgxoWFGB4PcFvJXJQloPhaV2eP3Q6EA=="],
 
-    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -149,7 +155,13 @@
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
+    "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
+
+    "react-dom": ["react-dom@19.2.3", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 

--- a/index.ts
+++ b/index.ts
@@ -338,7 +338,13 @@ async function handleExplore(rawArgs: string[]): Promise<void> {
 			runId = rawArgs[i];
 		} else if (arg === "--port") {
 			i++;
+			if (i >= rawArgs.length || !rawArgs[i]) {
+				throw new Error("--port requires a value. Usage: --port <number>");
+			}
 			port = Number.parseInt(rawArgs[i]!, 10);
+			if (Number.isNaN(port) || port < 1 || port > 65535) {
+				throw new Error("--port must be an integer between 1 and 65535");
+			}
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -21,9 +21,13 @@
 		"@ai-sdk/google-vertex": "^3.0.74",
 		"@ai-sdk/openai": "^2.0.88",
 		"@anthropic-ai/vertex-sdk": "^0.14.0",
+		"@types/react": "^19.2.7",
+		"@types/react-dom": "^19.2.3",
 		"ai": "^5.0.44",
 		"bun": "^1.3.5",
 		"dedent": "^1.7.0",
+		"react": "^19.2.3",
+		"react-dom": "^19.2.3",
 		"zod": "^4.1.9"
 	}
 }

--- a/src/explorer/export.ts
+++ b/src/explorer/export.ts
@@ -1,0 +1,199 @@
+import { join } from "node:path";
+import { readdir } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import type { MetricsSummary, RunManifest, ResultRecord } from "../results/schema";
+import { buildMetricsSummary } from "../results/summarize";
+import { getRunDir, readExistingResults } from "../results/writer";
+import type { ExplorerData, RunInfo } from "./types";
+
+/**
+ * Computes summary statistics from results when metrics_summary.json is missing.
+ */
+function computeSummaryFromResults(runId: string, results: ResultRecord[]): MetricsSummary {
+	const totals = {
+		cases: results.length,
+		passed: 0,
+		failed: 0,
+		skipped: 0,
+		errors: 0,
+		duration_ms: 0,
+	};
+
+	for (const result of results) {
+		totals.duration_ms += result.duration_ms;
+		switch (result.status) {
+			case "pass":
+				totals.passed++;
+				break;
+			case "fail":
+				totals.failed++;
+				break;
+			case "skip":
+				totals.skipped++;
+				break;
+			case "error":
+				totals.errors++;
+				break;
+		}
+	}
+
+	return {
+		version: 1,
+		run_id: runId,
+		generated_at: new Date().toISOString(),
+		totals,
+		by_combination: [],
+	};
+}
+
+async function countJsonlLines(path: string): Promise<number | undefined> {
+	try {
+		const file = Bun.file(path);
+		if (!(await file.exists())) {
+			return undefined;
+		}
+
+		const reader = file.stream().getReader();
+		let sawByte = false;
+		let lastByte = 0;
+		let lines = 0;
+
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value) continue;
+
+			sawByte = true;
+			lastByte = value[value.length - 1] ?? lastByte;
+
+			for (const byte of value) {
+				if (byte === 10) {
+					lines++;
+				}
+			}
+		}
+
+		// If the file has content and does not end with a newline, count the last line.
+		if (sawByte && lastByte !== 10) {
+			lines++;
+		}
+
+		return lines;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Loads all results and metadata for a given run and bundles them into ExplorerData.
+ *
+ * @param runId - Unique run identifier
+ * @param baseDir - Base directory for runs (default: "runs")
+ * @returns Bundled explorer data
+ */
+export async function loadExplorerData(
+	runId: string,
+	baseDir = "runs",
+): Promise<ExplorerData> {
+	const runDir = getRunDir(runId, baseDir);
+
+	const manifestPath = join(runDir, "run_manifest.json");
+	const summaryPath = join(runDir, "metrics_summary.json");
+
+	const manifestFile = Bun.file(manifestPath);
+	const summaryFile = Bun.file(summaryPath);
+
+	if (!(await manifestFile.exists())) {
+		throw new Error(`Run manifest not found in ${runDir}`);
+	}
+
+	const manifest = (await manifestFile.json()) as RunManifest;
+	const results = await readExistingResults(runDir);
+
+	// Prefer computing summary from results for consistency with the table view.
+	// Fall back to metrics_summary.json only if there are no parsed results.
+	let summary: MetricsSummary;
+	if (results.length > 0) {
+		summary = buildMetricsSummary(runId, results);
+	} else if (await summaryFile.exists()) {
+		summary = (await summaryFile.json()) as MetricsSummary;
+	} else {
+		summary = buildMetricsSummary(runId, results);
+	}
+
+	return {
+		manifest,
+		summary,
+		results,
+	};
+}
+
+/**
+ * Lists all available runs in the runs directory.
+ *
+ * @param baseDir - Base directory for runs (default: "runs")
+ * @returns Array of run info objects, sorted by timestamp (newest first)
+ */
+export async function listAvailableRuns(baseDir = "runs"): Promise<RunInfo[]> {
+	const runsPath = join(process.cwd(), baseDir);
+
+	let entries: Dirent[];
+	try {
+		entries = await readdir(runsPath, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+
+	const runDirs = entries
+		.filter((entry) => entry.isDirectory() && entry.name.startsWith("run_"))
+		.map((entry) => entry.name);
+	const runs: RunInfo[] = [];
+
+	for (const runDir of runDirs) {
+		const manifestPath = join(runsPath, runDir, "run_manifest.json");
+		const manifestFile = Bun.file(manifestPath);
+
+		if (await manifestFile.exists()) {
+			try {
+				const manifest = (await manifestFile.json()) as RunManifest;
+
+				// Try to get result count from metrics_summary.json (fast path)
+				let resultCount: number | undefined;
+				const summaryPath = join(runsPath, runDir, "metrics_summary.json");
+				const summaryFile = Bun.file(summaryPath);
+				if (await summaryFile.exists()) {
+					try {
+						const summary = (await summaryFile.json()) as MetricsSummary;
+						resultCount = summary.totals.cases;
+					} catch {
+						// Fall back to counting JSONL lines below
+					}
+				}
+
+				// Fallback: count results.jsonl lines without loading the entire file into memory
+				if (resultCount === undefined) {
+					const resultsPath = join(runsPath, runDir, "results.jsonl");
+					const counted = await countJsonlLines(resultsPath);
+					if (counted !== undefined) {
+						resultCount = counted;
+					}
+				}
+
+				runs.push({
+					run_id: manifest.run_id,
+					timestamp: manifest.timestamp,
+					providers: manifest.providers.map((p) => p.name),
+					benchmarks: manifest.benchmarks.map((b) => b.name),
+					result_count: resultCount,
+				});
+			} catch {
+				// Skip invalid manifests
+			}
+		}
+	}
+
+	// Sort by timestamp, newest first
+	runs.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+	return runs;
+}

--- a/src/explorer/frontend.tsx
+++ b/src/explorer/frontend.tsx
@@ -1,0 +1,1036 @@
+/// <reference lib="dom" />
+import React, { useState, useEffect, useMemo } from "react";
+import { createRoot } from "react-dom/client";
+import type { ResultRecord } from "../results/schema";
+import type { ExplorerData, RunInfo } from "./types";
+
+// --- Icon Component (uses Iconify loaded in HTML) ---
+// Use a wrapper div to prevent React/Iconify DOM conflicts
+function Icon({ name, className = "" }: { name: string; className?: string }) {
+	return (
+		<span
+			className={className}
+			dangerouslySetInnerHTML={{
+				__html: `<span class="iconify" data-icon="${name}"></span>`,
+			}}
+		/>
+	);
+}
+
+// --- Header Component ---
+function Header({
+	data,
+	onSelectRun,
+	onExport,
+}: { data: ExplorerData; onSelectRun: () => void; onExport: () => void }) {
+	const runDate = new Date(data.manifest.timestamp);
+	const timeAgo = getTimeAgo(runDate);
+
+	return (
+		<header className="flex flex-col md:flex-row md:items-end justify-between gap-4 border-b border-white/10 pb-6">
+			<div className="space-y-2">
+				<div className="flex items-center gap-2">
+					<div className="w-2 h-2 rounded-full bg-accent animate-pulse" />
+					<span className="text-xs font-mono text-accent uppercase tracking-widest">
+						Run Complete
+					</span>
+				</div>
+				<h1 className="text-3xl md:text-4xl font-medium text-white tracking-tight">
+					Results Explorer
+				</h1>
+				<p className="text-gray-500 font-mono text-xs">
+					Viewing Run:{" "}
+					<span className="text-white">{data.manifest.run_id}</span>
+					<span className="mx-2 text-white/20">|</span>
+					<span className="text-gray-600">{timeAgo}</span>
+				</p>
+			</div>
+
+			<div className="flex items-center gap-3">
+				<button
+					onClick={onSelectRun}
+					className="group relative px-6 py-2 bg-transparent text-white border border-white/20 hover:border-accent hover:text-accent transition-colors clip-chamfer"
+				>
+					<span className="text-xs font-bold uppercase tracking-wider">
+						Select Run
+					</span>
+				</button>
+				<button
+					onClick={onExport}
+					className="group relative px-6 py-2 bg-accent text-black hover:bg-white transition-colors clip-chamfer"
+				>
+					<div className="flex items-center gap-2">
+						<Icon name="lucide:download" />
+						<span className="text-xs font-bold uppercase tracking-wider">
+							Export
+						</span>
+					</div>
+				</button>
+			</div>
+		</header>
+	);
+}
+
+// --- Dashboard Cards ---
+function Dashboard({ data }: { data: ExplorerData }) {
+	const { totals } = data.summary;
+	const passRate =
+		totals.cases > 0 ? ((totals.passed / totals.cases) * 100).toFixed(1) : "0";
+	const avgDuration =
+		totals.cases > 0 ? Math.round(totals.duration_ms / totals.cases) : 0;
+
+	return (
+		<div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+			<MetricCard
+				icon="lucide:layers"
+				label="Total Cases"
+				value={totals.cases.toLocaleString()}
+				subtext={`${totals.passed} passed`}
+				subtextColor="text-green-500"
+			/>
+			<MetricCard
+				icon="lucide:clock"
+				label="Avg Duration"
+				value={avgDuration.toString()}
+				unit="ms"
+				subtext="Per case"
+			/>
+			<MetricCard
+				icon="lucide:check-circle"
+				label="Pass Rate"
+				value={passRate}
+				unit="%"
+				progress={Number.parseFloat(passRate)}
+			/>
+			<MetricCard
+				icon="lucide:server"
+				label="Providers"
+				value={data.manifest.providers.length.toString()}
+				subtext="In this run"
+			/>
+		</div>
+	);
+}
+
+function MetricCard({
+	icon,
+	label,
+	value,
+	unit,
+	subtext,
+	subtextColor = "text-gray-500",
+	progress,
+}: {
+	icon: string;
+	label: string;
+	value: string;
+	unit?: string;
+	subtext?: string;
+	subtextColor?: string;
+	progress?: number;
+}) {
+	return (
+		<div className="cursor-pointer p-6 bg-hex-card border border-white/10 relative overflow-hidden group hover:border-accent/50 transition-all duration-300">
+			<div className="absolute top-4 right-4 text-gray-700 group-hover:text-accent transition-colors">
+				<Icon name={icon} className="w-6 h-6" />
+			</div>
+			<div className="text-gray-500 text-[10px] uppercase tracking-widest font-mono mb-2">
+				{label}
+			</div>
+			<div className="text-3xl font-medium text-white">
+				{value}
+				{unit && <span className="text-lg text-gray-500 ml-1">{unit}</span>}
+			</div>
+			{progress !== undefined && (
+				<div className="w-full bg-gray-800 h-1 mt-3 overflow-hidden">
+					<div
+						className="bg-accent h-full transition-all duration-500"
+						style={{ width: `${progress}%` }}
+					/>
+				</div>
+			)}
+			{subtext && (
+				<div className={`mt-2 text-xs font-mono ${subtextColor}`}>{subtext}</div>
+			)}
+		</div>
+	);
+}
+
+// --- Filters Toolbar ---
+function Filters({
+	providers,
+	benchmarks,
+	selectedProvider,
+	setSelectedProvider,
+	selectedBenchmark,
+	setSelectedBenchmark,
+	statusFilter,
+	setStatusFilter,
+	caseQuery,
+	setCaseQuery,
+	filteredCount,
+	totalCount,
+}: {
+	providers: { name: string }[];
+	benchmarks: { name: string }[];
+	selectedProvider: string;
+	setSelectedProvider: (v: string) => void;
+	selectedBenchmark: string;
+	setSelectedBenchmark: (v: string) => void;
+	statusFilter: string;
+	setStatusFilter: (v: string) => void;
+	caseQuery: string;
+	setCaseQuery: (v: string) => void;
+	filteredCount: number;
+	totalCount: number;
+}) {
+	return (
+		<div className="flex flex-wrap items-center gap-4 p-4 bg-hex-surface border border-white/10 clip-chamfer">
+			<div className="flex items-center gap-3">
+				<Icon name="lucide:filter" className="text-accent" />
+				<span className="text-xs font-bold uppercase tracking-wider text-white">
+					Filters:
+				</span>
+			</div>
+
+			<div className="h-4 w-px bg-white/10" />
+
+			<div className="flex gap-4">
+				<FilterSelect
+					value={selectedProvider}
+					onChange={setSelectedProvider}
+					options={[
+						{ value: "all", label: "All Providers" },
+						...providers.map((p) => ({ value: p.name, label: p.name })),
+					]}
+				/>
+				<FilterSelect
+					value={selectedBenchmark}
+					onChange={setSelectedBenchmark}
+					options={[
+						{ value: "all", label: "All Benchmarks" },
+						...benchmarks.map((b) => ({ value: b.name, label: b.name })),
+					]}
+				/>
+				<FilterSelect
+					value={statusFilter}
+					onChange={setStatusFilter}
+					options={[
+						{ value: "all", label: "Any Status" },
+						{ value: "pass", label: "Passed" },
+						{ value: "fail", label: "Failed" },
+						{ value: "error", label: "Error" },
+						{ value: "skip", label: "Skipped" },
+					]}
+				/>
+				<div className="relative group">
+					<input
+						value={caseQuery}
+						onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+							setCaseQuery(e.target.value)
+						}
+						placeholder="Search Case ID"
+						className="bg-black border border-white/20 text-xs text-gray-300 pl-3 pr-8 py-1.5 focus:border-accent outline-none tracking-wide w-48"
+					/>
+					{caseQuery ? (
+						<button
+							type="button"
+							onClick={() => setCaseQuery("")}
+							className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-accent"
+						>
+							<Icon name="lucide:x" />
+						</button>
+					) : (
+						<span className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-gray-500">
+							<Icon name="lucide:search" />
+						</span>
+					)}
+				</div>
+			</div>
+
+			<div className="ml-auto flex items-center gap-2">
+				<span className="text-[10px] text-gray-500 font-mono">
+					Showing {filteredCount} of {totalCount}
+				</span>
+			</div>
+		</div>
+	);
+}
+
+function FilterSelect({
+	value,
+	onChange,
+	options,
+}: {
+	value: string;
+	onChange: (v: string) => void;
+	options: { value: string; label: string }[];
+}) {
+	return (
+		<div className="relative group">
+			<select
+				value={value}
+				onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
+				className="appearance-none bg-black border border-white/20 text-xs text-gray-300 pl-3 pr-8 py-1.5 focus:border-accent outline-none uppercase tracking-wide cursor-pointer w-40"
+			>
+				{options.map((opt) => (
+					<option key={opt.value} value={opt.value}>
+						{opt.label}
+					</option>
+				))}
+			</select>
+			<span className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-gray-500">
+				<Icon name="lucide:chevron-down" />
+			</span>
+		</div>
+	);
+}
+
+// --- Results Table ---
+function ResultsTable({
+	results,
+	onSelect,
+}: { results: ResultRecord[]; onSelect: (r: ResultRecord) => void }) {
+	const [sortKey, setSortKey] = useState<string>("case_id");
+	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
+	const [page, setPage] = useState(0);
+	const [pageSize, setPageSize] = useState(100);
+
+	const sortedResults = useMemo(() => {
+		return [...results].sort((a, b) => {
+			const valA = (a as unknown as Record<string, unknown>)[sortKey];
+			const valB = (b as unknown as Record<string, unknown>)[sortKey];
+			if (valA === undefined || valA === null || valB === undefined || valB === null) return 0;
+			if (valA < valB) return sortOrder === "asc" ? -1 : 1;
+			if (valA > valB) return sortOrder === "asc" ? 1 : -1;
+			return 0;
+		});
+	}, [results, sortKey, sortOrder]);
+
+	useEffect(() => {
+		setPage(0);
+	}, [results, pageSize]);
+
+	const pageCount = Math.max(1, Math.ceil(sortedResults.length / pageSize));
+	const clampedPage = Math.min(page, pageCount - 1);
+	const startIndex = clampedPage * pageSize;
+	const pageResults = sortedResults.slice(startIndex, startIndex + pageSize);
+
+	useEffect(() => {
+		if (page !== clampedPage) {
+			setPage(clampedPage);
+		}
+	}, [page, clampedPage]);
+
+	const handleSort = (key: string) => {
+		if (sortKey === key) {
+			setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+		} else {
+			setSortKey(key);
+			setSortOrder("asc");
+		}
+	};
+
+	const SortHeader = ({
+		field,
+		label,
+		align = "left",
+	}: { field: string; label: string; align?: "left" | "right" }) => (
+		<th
+			onClick={() => handleSort(field)}
+			className={`p-4 font-bold cursor-pointer hover:text-white transition-colors ${align === "right" ? "text-right" : ""}`}
+		>
+			<div
+				className={`flex items-center gap-1 ${align === "right" ? "justify-end" : ""}`}
+			>
+				{label}
+				{sortKey === field && (
+					<Icon
+						name={sortOrder === "asc" ? "lucide:arrow-up" : "lucide:arrow-down"}
+						className="w-3 h-3"
+					/>
+				)}
+			</div>
+		</th>
+	);
+
+	return (
+		<div className="overflow-hidden border border-white/10 bg-hex-card">
+			<table className="w-full text-left border-collapse text-xs font-mono">
+				<thead>
+					<tr className="border-b border-white/10 bg-white/5 text-gray-500 uppercase tracking-wider">
+						<SortHeader field="status" label="Status" />
+						<SortHeader field="case_id" label="Case ID" />
+						<SortHeader field="provider_name" label="Provider" />
+						<SortHeader field="benchmark_name" label="Benchmark" />
+						<SortHeader field="duration_ms" label="Duration" align="right" />
+						<th className="p-4 font-bold text-right">Scores</th>
+						<th className="p-4 font-bold w-12" />
+					</tr>
+				</thead>
+				<tbody className="divide-y divide-white/5">
+					{pageResults.length === 0 ? (
+						<tr>
+							<td colSpan={7} className="p-10 text-center text-gray-500">
+								No results match the current filters.
+							</td>
+						</tr>
+					) : (
+						pageResults.map((result) => (
+							<tr
+								key={`${result.run_id}:${result.provider_name}:${result.benchmark_name}:${result.case_id}`}
+								onClick={() => onSelect(result)}
+								className="group hover:bg-white/5 transition-colors cursor-pointer"
+							>
+								<td className="p-4">
+									<StatusIcon status={result.status} />
+								</td>
+								<td className="p-4 text-white font-medium">{result.case_id}</td>
+								<td className="p-4 text-gray-300">{result.provider_name}</td>
+								<td className="p-4 text-gray-400">{result.benchmark_name}</td>
+								<td className="p-4 text-right text-gray-500">
+									{result.duration_ms.toFixed(0)}ms
+								</td>
+								<td className="p-4 text-right">
+									{Object.entries(result.scores || {})
+										.slice(0, 2)
+										.map(([name, score]) => (
+											<div
+												key={name}
+												className={`text-[10px] ${(score as number) >= 0.7 ? "text-green-400" : "text-red-400"}`}
+											>
+												{name}: {((score as number) * 100).toFixed(0)}%
+											</div>
+										))}
+								</td>
+								<td className="p-4 text-center text-gray-600 group-hover:text-accent">
+									<Icon name="lucide:chevron-right" />
+								</td>
+							</tr>
+						))
+					)}
+				</tbody>
+			</table>
+			<div className="p-4 border-t border-white/5 flex flex-col md:flex-row md:items-center gap-3 justify-between bg-black/20">
+				<div className="flex items-center gap-3 text-[10px] text-gray-500 font-mono uppercase tracking-wider">
+					<span>Rows</span>
+					<div className="relative group">
+						<select
+							value={pageSize.toString()}
+							onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+								setPageSize(Number.parseInt(e.target.value, 10))
+							}
+							className="appearance-none bg-black border border-white/20 text-[10px] text-gray-300 pl-3 pr-8 py-1 focus:border-accent outline-none uppercase tracking-wide cursor-pointer"
+						>
+							<option value="50">50</option>
+							<option value="100">100</option>
+							<option value="200">200</option>
+							<option value="500">500</option>
+						</select>
+						<span className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-gray-500">
+							<Icon name="lucide:chevron-down" />
+						</span>
+					</div>
+				</div>
+
+				<div className="flex items-center justify-between md:justify-end gap-3">
+					<div className="text-[10px] text-gray-500 font-mono">
+						{sortedResults.length === 0
+							? "0 results"
+							: `${startIndex + 1}-${Math.min(startIndex + pageSize, sortedResults.length)} of ${sortedResults.length}`}
+					</div>
+					<div className="flex items-center gap-2">
+						<button
+							type="button"
+							disabled={clampedPage === 0}
+							onClick={() => setPage((p) => Math.max(0, p - 1))}
+							className="px-3 py-1 bg-hex-surface border border-white/10 hover:border-accent hover:text-accent disabled:opacity-50 disabled:hover:border-white/10 disabled:hover:text-gray-500 transition-colors clip-chamfer text-[10px] font-bold uppercase tracking-wider text-gray-300"
+						>
+							Prev
+						</button>
+						<button
+							type="button"
+							disabled={clampedPage >= pageCount - 1}
+							onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+							className="px-3 py-1 bg-hex-surface border border-white/10 hover:border-accent hover:text-accent disabled:opacity-50 disabled:hover:border-white/10 disabled:hover:text-gray-500 transition-colors clip-chamfer text-[10px] font-bold uppercase tracking-wider text-gray-300"
+						>
+							Next
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function StatusIcon({ status }: { status: string }) {
+	const config: Record<string, { icon: string; color: string }> = {
+		pass: { icon: "lucide:check-circle", color: "text-green-500" },
+		fail: { icon: "lucide:x-circle", color: "text-red-500" },
+		error: { icon: "lucide:alert-circle", color: "text-red-500" },
+		skip: { icon: "lucide:minus-circle", color: "text-yellow-500" },
+	};
+	const statusConfig = config[status] ?? config.skip!;
+	return (
+		<div className={`flex items-center gap-2 ${statusConfig.color}`}>
+			<Icon name={statusConfig.icon} />
+		</div>
+	);
+}
+
+// --- Drilldown Panel ---
+function Drilldown({
+	result,
+	onClose,
+}: { result: ResultRecord; onClose: () => void }) {
+	const hasScores: boolean =
+		result.scores != null && Object.keys(result.scores).length > 0;
+	const scores: Record<string, number> = result.scores ?? {};
+
+	return (
+		<div
+			className="fixed inset-0 bg-black/70 z-50 flex justify-end animate-reveal"
+			onClick={onClose}
+		>
+			<div
+				className="w-full max-w-2xl bg-hex-card h-full overflow-y-auto shadow-2xl"
+				onClick={(e) => e.stopPropagation()}
+			>
+				{/* Header */}
+				<div className="sticky top-0 bg-hex-card border-b border-white/10 p-6 flex items-center justify-between">
+					<div className="flex items-center gap-4">
+						<button
+							onClick={onClose}
+							className="flex items-center gap-2 px-4 py-2 bg-hex-surface border border-white/10 hover:border-accent hover:text-accent transition-colors clip-chamfer"
+						>
+							<Icon name="lucide:arrow-left" className="w-4 h-4" />
+							<span className="text-xs font-bold uppercase tracking-wider">
+								Back
+							</span>
+						</button>
+						<div className="h-8 w-px bg-white/10" />
+						<div>
+							<h2 className="text-xl font-medium text-white">
+								{result.case_id}
+							</h2>
+							<div className="text-[10px] font-mono text-gray-500 uppercase tracking-widest">
+								Drilldown Analysis
+							</div>
+						</div>
+					</div>
+					<StatusBadge status={result.status} />
+				</div>
+
+				{/* Content */}
+				<div className="p-6 space-y-6">
+					{/* Metadata Card */}
+					<div className="p-6 bg-hex-surface border border-white/10">
+						<div className="flex items-center gap-2 mb-4">
+							<Icon name="lucide:database" className="text-accent" />
+							<span className="text-xs font-bold uppercase tracking-wider text-white">
+								Metadata
+							</span>
+						</div>
+						<div className="space-y-3">
+							<MetadataRow label="Provider" value={result.provider_name} />
+							<MetadataRow label="Benchmark" value={result.benchmark_name} />
+							<MetadataRow
+								label="Duration"
+								value={`${result.duration_ms.toFixed(0)}ms`}
+							/>
+							<MetadataRow label="Run ID" value={result.run_id} />
+						</div>
+					</div>
+
+					{/* Scores Card */}
+					{hasScores ? (
+						<div className="p-6 bg-hex-surface border border-white/10">
+							<div className="flex items-center gap-2 mb-4">
+								<Icon name="lucide:bar-chart-2" className="text-accent" />
+								<span className="text-xs font-bold uppercase tracking-wider text-white">
+									Scores
+								</span>
+							</div>
+							<div className="grid grid-cols-2 gap-4">
+								{Object.entries(scores).map(([name, scoreValue]) => {
+									const score =
+										typeof scoreValue === "number" ? scoreValue : 0;
+									return (
+										<div
+											key={name}
+											className="p-3 bg-black/30 border border-white/5"
+										>
+											<div className="text-[10px] text-gray-500 uppercase mb-1">
+												{name}
+											</div>
+											<div
+												className={`text-xl font-medium ${score >= 0.7 ? "text-green-400" : "text-red-400"}`}
+											>
+												{(score * 100).toFixed(1)}%
+											</div>
+										</div>
+									);
+								})}
+							</div>
+						</div>
+					) : null}
+
+					{/* Error Card */}
+					{result.error && (
+						<div className="p-6 bg-red-500/5 border border-red-500/30">
+							<div className="flex items-center gap-2 mb-4">
+								<Icon name="lucide:alert-triangle" className="text-red-500" />
+								<span className="text-xs font-bold uppercase tracking-wider text-red-500">
+									Error
+								</span>
+							</div>
+							<pre className="text-xs text-red-300 font-mono whitespace-pre-wrap overflow-x-auto">
+								{typeof result.error === "string"
+									? result.error
+									: JSON.stringify(result.error, null, 2)}
+							</pre>
+						</div>
+					)}
+
+					{/* Details Card - REMOVED: "details" property not in ResultRecord type */}
+
+					{/* Raw Result */}
+					<details className="group">
+						<summary className="cursor-pointer text-xs text-gray-500 hover:text-white transition-colors flex items-center gap-2">
+							<Icon
+								name="lucide:chevron-right"
+								className="w-4 h-4 group-open:rotate-90 transition-transform"
+							/>
+							<span className="uppercase tracking-wider">View Raw Result</span>
+						</summary>
+						<pre className="mt-4 text-xs text-gray-400 font-mono whitespace-pre-wrap overflow-x-auto bg-black/30 p-4 border border-white/5">
+							{JSON.stringify(result, null, 2)}
+						</pre>
+					</details>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function StatusBadge({ status }: { status: string }) {
+	const config: Record<string, { bg: string; border: string; text: string }> = {
+		pass: {
+			bg: "bg-green-500/10",
+			border: "border-green-500",
+			text: "text-green-500",
+		},
+		fail: {
+			bg: "bg-red-500/10",
+			border: "border-red-500",
+			text: "text-red-500",
+		},
+		error: {
+			bg: "bg-red-500/10",
+			border: "border-red-500",
+			text: "text-red-500",
+		},
+		skip: {
+			bg: "bg-yellow-500/10",
+			border: "border-yellow-500",
+			text: "text-yellow-500",
+		},
+	};
+	const statusConfig = config[status] ?? config.skip!;
+	return (
+		<span
+			className={`px-3 py-1 ${statusConfig.bg} border ${statusConfig.border} ${statusConfig.text} text-xs font-bold uppercase tracking-widest clip-chamfer`}
+		>
+			{status}
+		</span>
+	);
+}
+
+function MetadataRow({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="flex justify-between text-xs">
+			<span className="text-gray-500">{label}</span>
+			<span className="text-white font-mono">{value}</span>
+		</div>
+	);
+}
+
+// --- Run Picker Modal ---
+function RunPicker({
+	runs,
+	currentRunId,
+	onSelect,
+	onClose,
+	loading,
+}: {
+	runs: RunInfo[];
+	currentRunId: string;
+	onSelect: (runId: string) => void;
+	onClose: () => void;
+	loading: boolean;
+}) {
+	return (
+		<div
+			className="fixed inset-0 bg-black/70 z-50 flex items-center justify-center animate-reveal"
+			onClick={onClose}
+		>
+			<div
+				className="w-full max-w-2xl bg-hex-card max-h-[80vh] overflow-hidden shadow-2xl border border-white/10"
+				onClick={(e) => e.stopPropagation()}
+			>
+				{/* Header */}
+				<div className="sticky top-0 bg-hex-card border-b border-white/10 p-6 flex items-center justify-between">
+					<div className="flex items-center gap-4">
+						<Icon name="lucide:folder-open" className="text-accent w-6 h-6" />
+						<div>
+							<h2 className="text-xl font-medium text-white">Select Run</h2>
+							<div className="text-[10px] font-mono text-gray-500 uppercase tracking-widest">
+								{runs.length} runs available
+							</div>
+						</div>
+					</div>
+					<button
+						onClick={onClose}
+						className="p-2 hover:bg-white/10 transition-colors"
+					>
+						<Icon name="lucide:x" className="w-5 h-5 text-gray-400 hover:text-white" />
+					</button>
+				</div>
+
+				{/* Content */}
+				<div className="overflow-y-auto max-h-[60vh] p-4">
+					{loading ? (
+						<div className="flex items-center justify-center py-12">
+							<Icon name="lucide:loader-2" className="w-6 h-6 animate-spin text-accent" />
+							<span className="ml-2 text-gray-500">Loading runs...</span>
+						</div>
+					) : runs.length === 0 ? (
+						<div className="text-center py-12 text-gray-500">
+							No runs found in the runs folder.
+						</div>
+					) : (
+						<div className="space-y-2">
+							{runs.map((run) => {
+								const isCurrentRun = run.run_id === currentRunId;
+								const runDate = new Date(run.timestamp);
+								const timeAgo = getTimeAgo(runDate);
+
+								return (
+									<button
+										key={run.run_id}
+										onClick={() => !isCurrentRun && onSelect(run.run_id)}
+										disabled={isCurrentRun}
+										className={`w-full text-left p-4 border transition-all ${
+											isCurrentRun
+												? "border-accent bg-accent/10 cursor-default"
+												: "border-white/10 hover:border-accent/50 hover:bg-white/5 cursor-pointer"
+										}`}
+									>
+										<div className="flex items-start justify-between">
+											<div className="space-y-1">
+												<div className="flex items-center gap-2">
+													<span className="text-white font-mono text-sm">
+														{run.run_id}
+													</span>
+													{isCurrentRun && (
+														<span className="px-2 py-0.5 bg-accent/20 text-accent text-[10px] uppercase tracking-wider">
+															Current
+														</span>
+													)}
+												</div>
+												<div className="text-[10px] text-gray-500 font-mono">
+													{runDate.toLocaleString()} ({timeAgo})
+												</div>
+												<div className="flex flex-wrap gap-2 mt-2">
+													{run.providers.map((p) => (
+														<span
+															key={p}
+															className="px-2 py-0.5 bg-blue-500/10 border border-blue-500/30 text-blue-400 text-[10px]"
+														>
+															{p}
+														</span>
+													))}
+													{run.benchmarks.map((b) => (
+														<span
+															key={b}
+															className="px-2 py-0.5 bg-purple-500/10 border border-purple-500/30 text-purple-400 text-[10px]"
+														>
+															{b}
+														</span>
+													))}
+												</div>
+											</div>
+											<div className="text-right">
+												{run.result_count !== undefined && (
+													<div className="text-gray-400 text-xs">
+														{run.result_count} results
+													</div>
+												)}
+											</div>
+										</div>
+									</button>
+								);
+							})}
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// --- Utility Functions ---
+function getTimeAgo(date: Date): string {
+	const now = new Date();
+	const diffMs = now.getTime() - date.getTime();
+	const diffMins = Math.floor(diffMs / 60000);
+	const diffHours = Math.floor(diffMins / 60);
+	const diffDays = Math.floor(diffHours / 24);
+
+	if (diffDays > 0) return `${diffDays}d ago`;
+	if (diffHours > 0) return `${diffHours}h ago`;
+	if (diffMins > 0) return `${diffMins}m ago`;
+	return "Just now";
+}
+
+// --- Main App ---
+export function App() {
+	const [data, setData] = useState<ExplorerData | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const [selectedProvider, setSelectedProvider] = useState("all");
+	const [selectedBenchmark, setSelectedBenchmark] = useState("all");
+	const [statusFilter, setStatusFilter] = useState("all");
+	const [caseQuery, setCaseQuery] = useState("");
+	const [selectedResult, setSelectedResult] = useState<ResultRecord | null>(
+		null,
+	);
+
+	// Run picker state
+	const [showRunPicker, setShowRunPicker] = useState(false);
+	const [availableRuns, setAvailableRuns] = useState<RunInfo[]>([]);
+	const [loadingRuns, setLoadingRuns] = useState(false);
+
+	// Fetch initial data
+	useEffect(() => {
+		fetch("/api/data")
+			.then((res) => {
+				if (!res.ok) throw new Error(`HTTP ${res.status}`);
+				return res.json() as Promise<ExplorerData>;
+			})
+			.then((fetchedData) => {
+				setData(fetchedData);
+				setLoading(false);
+			})
+			.catch((err: Error) => {
+				setError(err.message);
+				setLoading(false);
+			});
+	}, []);
+
+	// Fetch available runs when picker opens
+	const handleOpenRunPicker = () => {
+		setShowRunPicker(true);
+		setLoadingRuns(true);
+		fetch("/api/runs")
+			.then((res) => {
+				if (!res.ok) throw new Error(`HTTP ${res.status}`);
+				return res.json() as Promise<RunInfo[]>;
+			})
+			.then((runs) => {
+				setAvailableRuns(runs);
+				setLoadingRuns(false);
+			})
+			.catch(() => {
+				setAvailableRuns([]);
+				setLoadingRuns(false);
+			});
+	};
+
+	// Switch to a different run
+	const handleSelectRun = (runId: string) => {
+		setShowRunPicker(false);
+		setLoading(true);
+		setError(null);
+
+		fetch(`/api/run/${runId}`)
+			.then((res) => {
+				if (!res.ok) throw new Error(`Failed to switch run`);
+				return res.json();
+			})
+			.then(() => {
+				// Fetch the new data
+				return fetch("/api/data");
+			})
+			.then((res) => {
+				if (!res.ok) throw new Error(`HTTP ${res.status}`);
+				return res.json() as Promise<ExplorerData>;
+			})
+			.then((fetchedData) => {
+				setData(fetchedData);
+				setLoading(false);
+				// Reset filters when switching runs
+				setSelectedProvider("all");
+				setSelectedBenchmark("all");
+				setStatusFilter("all");
+				setCaseQuery("");
+				setSelectedResult(null);
+			})
+			.catch((err: Error) => {
+				setError(err.message);
+				setLoading(false);
+			});
+	};
+
+	const availableProviders = useMemo(() => {
+		if (!data) return [];
+		const names = new Set<string>();
+
+		for (const result of data.results) {
+			names.add(result.provider_name);
+		}
+
+		for (const provider of data.manifest.providers) {
+			names.add(provider.name);
+		}
+
+		// If there are no results (e.g., parse error / empty file), still show manifest entries.
+		return [...names].sort().map((name) => ({ name }));
+	}, [data]);
+
+	const availableBenchmarks = useMemo(() => {
+		if (!data) return [];
+		const names = new Set<string>();
+
+		for (const result of data.results) {
+			names.add(result.benchmark_name);
+		}
+
+		for (const benchmark of data.manifest.benchmarks) {
+			names.add(benchmark.name);
+		}
+
+		return [...names].sort().map((name) => ({ name }));
+	}, [data]);
+
+	useEffect(() => {
+		if (selectedProvider === "all") return;
+		if (availableProviders.some((p) => p.name === selectedProvider)) return;
+		setSelectedProvider("all");
+	}, [availableProviders, selectedProvider]);
+
+	useEffect(() => {
+		if (selectedBenchmark === "all") return;
+		if (availableBenchmarks.some((b) => b.name === selectedBenchmark)) return;
+		setSelectedBenchmark("all");
+	}, [availableBenchmarks, selectedBenchmark]);
+
+	const filteredResults = useMemo(() => {
+		if (!data) return [];
+		const query = caseQuery.trim().toLowerCase();
+		return data.results.filter((r) => {
+			if (selectedProvider !== "all" && r.provider_name !== selectedProvider)
+				return false;
+			if (selectedBenchmark !== "all" && r.benchmark_name !== selectedBenchmark)
+				return false;
+			if (statusFilter !== "all" && r.status !== statusFilter) return false;
+			if (query && !r.case_id.toLowerCase().includes(query)) return false;
+			return true;
+		});
+	}, [data, selectedProvider, selectedBenchmark, statusFilter, caseQuery]);
+
+	const handleExport = () => {
+		if (!data) return;
+		const payload = JSON.stringify(data, null, 2);
+		const blob = new Blob([payload], { type: "application/json" });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = `memorybench_${data.manifest.run_id}.json`;
+		document.body.appendChild(a);
+		a.click();
+		a.remove();
+		setTimeout(() => URL.revokeObjectURL(url), 1000);
+	};
+
+	if (loading) {
+		return (
+			<div className="flex items-center justify-center py-20">
+				<div className="flex items-center gap-3 text-gray-500">
+					<Icon name="lucide:loader-2" className="w-6 h-6 animate-spin" />
+					<span className="text-sm font-mono uppercase tracking-wider">
+						Loading Results...
+					</span>
+				</div>
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="flex flex-col items-center justify-center py-20 gap-4">
+				<Icon name="lucide:alert-circle" className="w-12 h-12 text-red-500" />
+				<div className="text-red-400 font-mono text-sm">Error: {error}</div>
+				<button
+					onClick={() => window.location.reload()}
+					className="px-6 py-2 bg-hex-surface border border-white/20 hover:border-accent text-white text-xs font-bold uppercase tracking-wider clip-chamfer"
+				>
+					Retry
+				</button>
+			</div>
+		);
+	}
+
+	if (!data) {
+		return (
+			<div className="flex items-center justify-center py-20">
+				<div className="text-gray-500 font-mono text-sm">No data found.</div>
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<Header data={data} onSelectRun={handleOpenRunPicker} onExport={handleExport} />
+			<Dashboard data={data} />
+			<Filters
+				providers={availableProviders}
+				benchmarks={availableBenchmarks}
+				selectedProvider={selectedProvider}
+				setSelectedProvider={setSelectedProvider}
+				selectedBenchmark={selectedBenchmark}
+				setSelectedBenchmark={setSelectedBenchmark}
+				statusFilter={statusFilter}
+				setStatusFilter={setStatusFilter}
+				caseQuery={caseQuery}
+				setCaseQuery={setCaseQuery}
+				filteredCount={filteredResults.length}
+				totalCount={data.results.length}
+			/>
+			<ResultsTable results={filteredResults} onSelect={setSelectedResult} />
+			{selectedResult && (
+				<Drilldown
+					result={selectedResult}
+					onClose={() => setSelectedResult(null)}
+				/>
+			)}
+			{showRunPicker && (
+				<RunPicker
+					runs={availableRuns}
+					currentRunId={data.manifest.run_id}
+					onSelect={handleSelectRun}
+					onClose={() => setShowRunPicker(false)}
+					loading={loadingRuns}
+				/>
+			)}
+		</>
+	);
+}
+
+// --- Mount React ---
+const container = document.getElementById("root");
+if (container) {
+	const root = createRoot(container);
+	root.render(<App />);
+}

--- a/src/explorer/index.html
+++ b/src/explorer/index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MemoryBench Explorer</title>
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+
+    <!-- Tailwind -->
+    <script src="https://cdn.tailwindcss.com"></script>
+
+    <!-- Icons -->
+    <script src="https://code.iconify.design/3/3.1.0/iconify.min.js"></script>
+
+    <!-- Tailwind Configuration -->
+    <script>
+      tailwind.config = {
+          theme: {
+              extend: {
+                  fontFamily: {
+                      sans: ['Inter', 'sans-serif'],
+                      mono: ['JetBrains Mono', 'monospace'],
+                  },
+                  colors: {
+                      accent: {
+                          DEFAULT: '#E0FF00',
+                          glow: 'rgba(224, 255, 0, 0.5)',
+                          dim: 'rgba(224, 255, 0, 0.1)'
+                      },
+                      hex: {
+                           bg: '#050505',
+                           card: '#0F0F0F',
+                           surface: '#1B2124',
+                           border: 'rgba(255, 255, 255, 0.1)'
+                      }
+                  },
+                  animation: {
+                      'spin-slow': 'spin-hex 8s linear infinite',
+                  },
+                  keyframes: {
+                      'spin-hex': {
+                          '0%': { transform: 'rotate(0deg)' },
+                          '100%': { transform: 'rotate(360deg)' }
+                      }
+                  }
+              }
+          }
+      }
+    </script>
+
+    <style>
+      body {
+          background-color: #050505;
+          color: #E5E5E5;
+          font-feature-settings: "ss01", "ss04";
+          -webkit-font-smoothing: antialiased;
+      }
+
+      .bg-grid {
+          background-image:
+            linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+          background-size: 80px 80px;
+          background-position: -1px -1px;
+          opacity: 0.15;
+      }
+
+      /* HexOS Geometries */
+      .clip-hex {
+          clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+      }
+      .clip-chamfer {
+          clip-path: polygon(12px 0, 100% 0, 100% calc(100% - 12px), calc(100% - 12px) 100%, 0 100%, 0 12px);
+      }
+
+      /* Custom Scrollbar */
+      ::-webkit-scrollbar { width: 6px; height: 6px; }
+      ::-webkit-scrollbar-track { background: #050505; }
+      ::-webkit-scrollbar-thumb { background: #333; border-radius: 3px; }
+      ::-webkit-scrollbar-thumb:hover { background: #E0FF00; }
+
+      /* Utilities */
+      .glass { background: rgba(5, 5, 5, 0.8); backdrop-filter: blur(12px); }
+
+      /* HexOS Animations */
+      @keyframes ripple-out {
+        0% { transform: scale(0.8); opacity: 0.5; border-width: 2px; }
+        100% { transform: scale(1.4); opacity: 0; border-width: 0px; }
+      }
+      @keyframes reveal-scale {
+        0% { transform: scale(0.98); opacity: 0; }
+        100% { transform: scale(1); opacity: 1; }
+      }
+      .animate-ripple { animation: ripple-out 0.6s ease-out forwards; }
+      .animate-reveal { animation: reveal-scale 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
+    </style>
+</head>
+<body class="selection:bg-[#E0FF00] selection:text-[#050505] min-h-screen flex flex-col bg-[#050505] font-sans">
+    <!-- Background Grid -->
+    <div class="fixed inset-0 bg-grid pointer-events-none z-0"></div>
+
+    <!-- Navigation -->
+    <nav class="sticky top-0 z-50 glass border-b border-white/10 w-full">
+      <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
+        <!-- HexOS Logo -->
+        <div class="flex items-center gap-3">
+          <div class="w-8 h-8 flex items-center justify-center bg-hex-surface border border-white/20 text-accent clip-hex">
+            <span class="iconify w-4 h-4" data-icon="lucide:hexagon"></span>
+          </div>
+          <div class="flex flex-col">
+            <span class="text-sm font-semibold tracking-tight text-white uppercase">
+              MemoryBench
+            </span>
+            <span class="text-[10px] text-gray-500 font-mono tracking-widest uppercase">
+              Explorer v0.1
+            </span>
+          </div>
+        </div>
+
+        <!-- Dashboard Controls -->
+        <div class="flex items-center gap-6 text-xs font-medium tracking-tight text-gray-400">
+          <a href="#" class="hover:text-accent transition-colors flex items-center gap-2">
+            <span class="iconify" data-icon="lucide:layout-dashboard"></span>
+            Dashboard
+          </a>
+          <a href="#" class="hover:text-accent transition-colors flex items-center gap-2">
+            <span class="iconify" data-icon="lucide:list"></span>
+            Runs
+          </a>
+          <div class="h-4 w-px bg-white/10"></div>
+          <a href="https://github.com/sdamache/memorybench" class="hover:text-white transition-colors">
+            <span class="iconify w-5 h-5" data-icon="lucide:github"></span>
+          </a>
+        </div>
+      </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main class="max-w-7xl mx-auto px-6 py-8 flex-1 w-full">
+      <!-- React Mount Point -->
+      <div id="root" class="space-y-8">
+        <!-- Loading State -->
+        <div class="flex items-center justify-center py-20">
+          <div class="flex items-center gap-3 text-gray-500">
+            <span class="iconify w-6 h-6 animate-spin" data-icon="lucide:loader-2"></span>
+            <span class="text-sm font-mono uppercase tracking-wider">Loading Explorer...</span>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-white/10 bg-[#0A0A0A] py-8">
+      <div class="max-w-7xl mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-4 text-xs text-gray-500 font-mono">
+        <p>HexOS Design System v2.2 // MemoryBench Explorer</p>
+        <div class="flex items-center gap-4">
+          <div class="flex items-center gap-2">
+            <div class="w-2 h-2 bg-accent rounded-full animate-pulse"></div>
+            <span>System Online</span>
+          </div>
+          <div class="w-px h-3 bg-white/10"></div>
+          <span>React v19</span>
+        </div>
+      </div>
+    </footer>
+
+    <!-- React App Bundle -->
+    <script type="module" src="/frontend.js"></script>
+</body>
+</html>

--- a/src/explorer/index.ts
+++ b/src/explorer/index.ts
@@ -1,0 +1,97 @@
+import { join } from "node:path";
+import { loadExplorerData, listAvailableRuns } from "./export";
+
+/**
+ * Starts the Results Explorer server.
+ * Bundles the React frontend and serves it along with the run data.
+ *
+ * @param runId - Unique run identifier to explore
+ * @param port - Port to run the server on (default: 3000)
+ * @returns The Bun server instance
+ */
+export async function startExplorer(runId: string, port = 3000) {
+	console.log(`Loading data for run: ${runId}...`);
+
+	let currentRunId = runId;
+	const noStoreHeaders = { "Cache-Control": "no-store" } as const;
+
+	console.log("Bundling frontend...");
+	const buildResult = await Bun.build({
+		entrypoints: [join(import.meta.dir, "frontend.tsx")],
+		minify: false,
+		sourcemap: "inline",
+	});
+
+	if (!buildResult.success) {
+		console.error("Build failed:");
+		for (const message of buildResult.logs) {
+			console.error(message);
+		}
+		throw new Error("Failed to bundle frontend");
+	}
+
+	const frontendJs = buildResult.outputs[0];
+
+	const server = Bun.serve({
+		port,
+		async fetch(req) {
+			const url = new URL(req.url);
+
+			// API endpoint for current run data
+			if (url.pathname === "/api/data") {
+				try {
+					const data = await loadExplorerData(currentRunId);
+					return Response.json(data, { headers: noStoreHeaders });
+				} catch (err) {
+					const message = err instanceof Error ? err.message : "Unknown error";
+					return Response.json({ error: message }, { status: 404, headers: noStoreHeaders });
+				}
+			}
+
+			// API endpoint for listing available runs
+			if (url.pathname === "/api/runs") {
+				const runs = await listAvailableRuns();
+				return Response.json(runs, { headers: noStoreHeaders });
+			}
+
+			// API endpoint for switching to a different run
+			if (url.pathname.startsWith("/api/run/")) {
+				const newRunId = url.pathname.replace("/api/run/", "");
+				try {
+					await loadExplorerData(newRunId);
+					currentRunId = newRunId;
+					return Response.json({ success: true, run_id: newRunId }, { headers: noStoreHeaders });
+				} catch (err) {
+					const message = err instanceof Error ? err.message : "Unknown error";
+					return Response.json({ success: false, error: message }, { status: 404, headers: noStoreHeaders });
+				}
+			}
+
+			// Serve static assets
+			if (url.pathname === "/" || url.pathname === "/index.html") {
+				return new Response(Bun.file(join(import.meta.dir, "index.html")), {
+					headers: { "Content-Type": "text/html; charset=utf-8", ...noStoreHeaders },
+				});
+			}
+
+			if (url.pathname === "/styles.css") {
+				return new Response(Bun.file(join(import.meta.dir, "styles.css")), {
+					headers: { "Content-Type": "text/css; charset=utf-8", ...noStoreHeaders },
+				});
+			}
+
+			if (url.pathname === "/frontend.js") {
+				return new Response(frontendJs, {
+					headers: { "Content-Type": "text/javascript; charset=utf-8", ...noStoreHeaders },
+				});
+			}
+
+			return new Response("Not Found", { status: 404 });
+		},
+	});
+
+	console.log(`\n🚀 Explorer running at http://localhost:${server.port}`);
+	console.log("Press Ctrl+C to stop.\n");
+
+	return server;
+}

--- a/src/explorer/styles.css
+++ b/src/explorer/styles.css
@@ -1,0 +1,182 @@
+:root {
+	--bg-primary: #0f172a;
+	--bg-secondary: #1e293b;
+	--text-primary: #f8fafc;
+	--text-secondary: #94a3b8;
+	--accent: #3b82f6;
+	--success: #22c55e;
+	--error: #ef4444;
+	--warning: #f59e0b;
+	--border: #334155;
+}
+
+body {
+	margin: 0;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+		Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+	background-color: var(--bg-primary);
+	color: var(--text-primary);
+}
+
+.container {
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 2rem;
+}
+
+header {
+	margin-bottom: 2rem;
+	border-bottom: 1px solid var(--border);
+	padding-bottom: 1rem;
+}
+
+.dashboard-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+	gap: 1rem;
+	margin-bottom: 2rem;
+}
+
+.card {
+	background-color: var(--bg-secondary);
+	padding: 1.5rem;
+	border-radius: 0.5rem;
+	border: 1px solid var(--border);
+}
+
+.card h3 {
+	margin-top: 0;
+	color: var(--text-secondary);
+	font-size: 0.875rem;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+.card .value {
+	font-size: 2rem;
+	font-weight: bold;
+}
+
+.filters {
+	display: flex;
+	gap: 1rem;
+	margin-bottom: 1.5rem;
+	flex-wrap: wrap;
+}
+
+.filter-group {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.filter-group label {
+	font-size: 0.75rem;
+	color: var(--text-secondary);
+}
+
+select {
+	background-color: var(--bg-secondary);
+	color: var(--text-primary);
+	border: 1px solid var(--border);
+	padding: 0.5rem;
+	border-radius: 0.25rem;
+}
+
+table {
+	width: 100%;
+	border-collapse: collapse;
+	background-color: var(--bg-secondary);
+	border-radius: 0.5rem;
+	overflow: hidden;
+}
+
+th,
+td {
+	padding: 1rem;
+	text-align: left;
+	border-bottom: 1px solid var(--border);
+}
+
+th {
+	background-color: rgba(0, 0, 0, 0.2);
+	color: var(--text-secondary);
+	font-weight: 500;
+	cursor: pointer;
+}
+
+th:hover {
+	color: var(--text-primary);
+}
+
+tr:hover {
+	background-color: rgba(255, 255, 255, 0.05);
+}
+
+.status-badge {
+	padding: 0.25rem 0.5rem;
+	border-radius: 1rem;
+	font-size: 0.75rem;
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
+.status-passed {
+	background-color: rgba(34, 197, 94, 0.2);
+	color: #4ade80;
+}
+.status-failed {
+	background-color: rgba(239, 68, 68, 0.2);
+	color: #f87171;
+}
+.status-error {
+	background-color: rgba(239, 68, 68, 0.2);
+	color: #f87171;
+}
+.status-skipped {
+	background-color: rgba(245, 158, 11, 0.2);
+	color: #fbbf24;
+}
+
+.drilldown-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: rgba(0, 0, 0, 0.7);
+	display: flex;
+	justify-content: flex-end;
+	z-index: 100;
+}
+
+.drilldown-panel {
+	width: 100%;
+	max-width: 600px;
+	background-color: var(--bg-secondary);
+	height: 100%;
+	padding: 2rem;
+	overflow-y: auto;
+	box-shadow: -4px 0 15px rgba(0, 0, 0, 0.5);
+}
+
+pre {
+	background-color: var(--bg-primary);
+	padding: 1rem;
+	border-radius: 0.5rem;
+	overflow-x: auto;
+	font-size: 0.875rem;
+}
+
+.close-btn {
+	background: none;
+	border: none;
+	color: var(--text-secondary);
+	font-size: 1.5rem;
+	cursor: pointer;
+	float: right;
+}
+
+.close-btn:hover {
+	color: var(--text-primary);
+}

--- a/src/explorer/types.ts
+++ b/src/explorer/types.ts
@@ -1,0 +1,34 @@
+import type {
+	MetricsSummary,
+	ResultRecord,
+	RunManifest,
+} from "../results/schema";
+
+/**
+ * Data bundle for the Results Explorer.
+ * Contains everything needed to render the explorer UI for a single run.
+ */
+export interface ExplorerData {
+	/** The run configuration and metadata */
+	manifest: RunManifest;
+	/** The aggregated metrics and statistics */
+	summary: MetricsSummary;
+	/** The individual case results */
+	results: ResultRecord[];
+}
+
+/**
+ * Brief info about a run for the run picker.
+ */
+export interface RunInfo {
+	/** Unique run identifier */
+	run_id: string;
+	/** When the run was started */
+	timestamp: string;
+	/** List of providers used */
+	providers: string[];
+	/** List of benchmarks used */
+	benchmarks: string[];
+	/** Number of results (if available) */
+	result_count?: number;
+}


### PR DESCRIPTION
## Summary

Implements a minimal browsable results explorer as specified in Issue #10. This adds an interactive web-based UI for exploring benchmark run results.

- **Core data loading**: Types and utilities for loading run data, computing stats from results when `metrics_summary.json` is missing, and listing available runs
- **Bun server**: API endpoints for fetching run data (`/api/data`), listing runs (`/api/runs`), and switching runs (`/api/run/:runId`)
- **React frontend**: Dashboard with stats cards, sortable/filterable results table, run picker modal, and result detail panel
- **CLI integration**: New `explore` command with `--run` and `--port` options

### Features
- 📊 Stats cards showing Total Cases, Avg Duration, Pass Rate, Providers count
- 🔍 Filter by provider, benchmark, status, and case ID search
- 📋 Sortable results table with pagination
- 🔄 Run picker to switch between different benchmark runs

## Test plan

- [x] Run `bun run index.ts explore --run <run_id>` to start explorer
- [x] Verify stats cards display correct values computed from results
- [x] Test all filters (provider, benchmark, status)
- [x] Test table sorting by clicking column headers
- [x] Test run switching via "Select Run" button
- [x] Verify result detail panel opens when clicking a row

🤖 Generated with [Claude Code](https://claude.com/claude-code)