### PR TITLE
feat: LocalBaseline provider with BM25 retrieval (Issue #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ bun run index.ts list benchmarks
 bun run index.ts list providers
 
 # Run a single benchmark against a single provider
-bun run index.ts eval --providers quickstart-test --benchmarks RAG-template-benchmark
+bun run index.ts eval --providers LocalBaseline --benchmarks RAG-template-benchmark
 
 # Run with concurrent execution for faster results
-bun run index.ts eval --providers quickstart-test --benchmarks RAG-template-benchmark --concurrency 4
+bun run index.ts eval --providers LocalBaseline --benchmarks RAG-template-benchmark --concurrency 4
 ```
 
 ## Running Benchmarks
@@ -25,7 +25,7 @@ bun run index.ts eval --providers quickstart-test --benchmarks RAG-template-benc
 Run a provider against a benchmark and get structured JSON results:
 
 ```bash
-bun run index.ts eval --providers quickstart-test --benchmarks RAG-template-benchmark
+bun run index.ts eval --providers LocalBaseline --benchmarks RAG-template-benchmark
 ```
 
 Output includes:
@@ -40,7 +40,7 @@ Run multiple combinations in a single evaluation:
 
 ```bash
 bun run index.ts eval \
-  --providers quickstart-test AQRAG \
+  --providers LocalBaseline AQRAG \
   --benchmarks RAG-template-benchmark LongMemEval
 ```
 
@@ -52,7 +52,7 @@ Speed up evaluations by running cases in parallel:
 
 ```bash
 bun run index.ts eval \
-  --providers quickstart-test \
+  --providers LocalBaseline \
   --benchmarks RAG-template-benchmark \
   --concurrency 4
 ```
@@ -65,7 +65,7 @@ The `eval` command outputs structured JSON to stdout and writes persistent resul
 
 ```bash
 bun run index.ts eval \
-  --providers quickstart-test \
+  --providers LocalBaseline \
   --benchmarks RAG-template-benchmark \
   > results.json
 ```
@@ -76,11 +76,11 @@ bun run index.ts eval \
 {
   "plan": {
     "entries": [{
-      "provider_name": "quickstart-test",
+      "provider_name": "LocalBaseline",
       "benchmark_name": "some-benchmark",
       "eligible": false,
       "skip_reason": {
-        "message": "Provider 'quickstart-test' lacks required capability: update_memory"
+        "message": "Provider 'LocalBaseline' lacks required capability: update_memory"
       }
     }]
   }
@@ -128,7 +128,7 @@ See [docs/output-format.md](docs/output-format.md) for complete schema documenta
 |----------|-------------|
 | ContextualRetrieval | Contextual chunking with embeddings |
 | AQRAG | Adaptive query RAG |
-| quickstart-test | Simple in-memory provider for testing |
+| LocalBaseline | In-memory provider with BM25 lexical retrieval (no API keys required) |
 
 ## Adding a Benchmark
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -92,13 +92,13 @@ interface EnvironmentInfo {
   "git_commit": "ff05810537391f301d492a5c4761605428b6e581",
   "git_branch": "009-results-writer",
   "selections": {
-    "providers": ["quickstart-test"],
+    "providers": ["LocalBaseline"],
     "benchmarks": ["RAG-template-benchmark"],
     "concurrency": 1
   },
   "providers": [
     {
-      "name": "quickstart-test",
+      "name": "LocalBaseline",
       "version": "1.0.0",
       "manifest_hash": "0e7a8d7add45784cd8ce0e373a9e4ace32371a81668b9142857dfbce1ebc55f8"
     }
@@ -120,7 +120,7 @@ interface EnvironmentInfo {
   "cli_args": [
     "eval",
     "--providers",
-    "quickstart-test",
+    "LocalBaseline",
     "--benchmarks",
     "RAG-template-benchmark",
     "--concurrency",
@@ -175,22 +175,22 @@ interface ResultRecord {
 
 **Passing case:**
 ```json
-{"run_id":"run_1766388833350_hpq76ud","provider_name":"quickstart-test","benchmark_name":"LongMemEval","case_id":"e47becba","status":"pass","scores":{"correctness":0.95,"faithfulness":0.92,"retrieval_precision":0.88,"retrieval_recall":0.91,"retrieval_f1":0.89},"duration_ms":1740,"artifacts":{"generatedAnswer":"The answer is 42","ingestedCount":53,"retrievedCount":5}}
+{"run_id":"run_1766388833350_hpq76ud","provider_name":"LocalBaseline","benchmark_name":"LongMemEval","case_id":"e47becba","status":"pass","scores":{"correctness":0.95,"faithfulness":0.92,"retrieval_precision":0.88,"retrieval_recall":0.91,"retrieval_f1":0.89},"duration_ms":1740,"artifacts":{"generatedAnswer":"The answer is 42","ingestedCount":53,"retrievedCount":5}}
 ```
 
 **Failing case:**
 ```json
-{"run_id":"run_1766388833350_hpq76ud","provider_name":"quickstart-test","benchmark_name":"RAG-template-benchmark","case_id":"rag_001","status":"fail","scores":{"precision":0,"retrieval_count":0,"top_score":0},"duration_ms":103}
+{"run_id":"run_1766388833350_hpq76ud","provider_name":"LocalBaseline","benchmark_name":"RAG-template-benchmark","case_id":"rag_001","status":"fail","scores":{"precision":0,"retrieval_count":0,"top_score":0},"duration_ms":103}
 ```
 
 **Failing case with error details in artifacts:**
 ```json
-{"run_id":"run_1766388833350_hpq76ud","provider_name":"quickstart-test","benchmark_name":"LongMemEval","case_id":"118b2229","status":"fail","scores":{"correctness":0,"faithfulness":0,"retrieval_precision":0,"retrieval_recall":0,"retrieval_f1":0},"duration_ms":200,"artifacts":{"generatedAnswer":"I don't have enough information to answer this question.","reasoning":"Judge error: 404 {\"error\":{\"code\":404,\"message\":\"Publisher Model not found.\",\"status\":\"NOT_FOUND\"}}","ingestedCount":45,"retrievedCount":0}}
+{"run_id":"run_1766388833350_hpq76ud","provider_name":"LocalBaseline","benchmark_name":"LongMemEval","case_id":"118b2229","status":"fail","scores":{"correctness":0,"faithfulness":0,"retrieval_precision":0,"retrieval_recall":0,"retrieval_f1":0},"duration_ms":200,"artifacts":{"generatedAnswer":"I don't have enough information to answer this question.","reasoning":"Judge error: 404 {\"error\":{\"code\":404,\"message\":\"Publisher Model not found.\",\"status\":\"NOT_FOUND\"}}","ingestedCount":45,"retrievedCount":0}}
 ```
 
 **Error case (execution failed):**
 ```json
-{"run_id":"run_1766388833350_hpq76ud","provider_name":"quickstart-test","benchmark_name":"LongMemEval","case_id":"118b2229","status":"error","scores":{},"duration_ms":50,"error":{"message":"Provider initialization failed: Database connection timeout","type":"ConnectionError"}}
+{"run_id":"run_1766388833350_hpq76ud","provider_name":"LocalBaseline","benchmark_name":"LongMemEval","case_id":"118b2229","status":"error","scores":{},"duration_ms":50,"error":{"message":"Provider initialization failed: Database connection timeout","type":"ConnectionError"}}
 ```
 
 ### Processing JSONL Files
@@ -290,7 +290,7 @@ interface CombinationSummary {
   },
   "by_combination": [
     {
-      "provider_name": "quickstart-test",
+      "provider_name": "LocalBaseline",
       "benchmark_name": "RAG-template-benchmark",
       "counts": {
         "cases": 3,

--- a/providers/LocalBaseline/manifest.json
+++ b/providers/LocalBaseline/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": "1",
 	"provider": {
-		"name": "quickstart-test",
+		"name": "LocalBaseline",
 		"type": "hybrid",
 		"version": "1.0.0"
 	},

--- a/src/utils/bm25.ts
+++ b/src/utils/bm25.ts
@@ -1,0 +1,125 @@
+/**
+ * BM25 (Best Matching 25) scoring algorithm for lexical retrieval.
+ * Used by LocalBaseline provider for deterministic, zero-dependency text matching.
+ *
+ * BM25 is an industry-standard probabilistic ranking function that considers:
+ * - Term frequency (TF): How often a term appears in a document
+ * - Inverse document frequency (IDF): How rare a term is across all documents
+ * - Document length normalization: Adjusts for varying document lengths
+ */
+
+// Standard BM25 parameters (empirically optimal for most use cases)
+const K1 = 1.5; // Term frequency saturation parameter
+const B = 0.75; // Document length normalization parameter
+
+/**
+ * Tokenize text into lowercase words, removing punctuation.
+ * @param text - Input text to tokenize
+ * @returns Array of lowercase tokens (words with length > 1)
+ */
+export function tokenize(text: string): string[] {
+	return text
+		.toLowerCase()
+		.replace(/[^\w\s]/g, " ") // Replace punctuation with spaces
+		.split(/\s+/) // Split on whitespace
+		.filter((token) => token.length > 1); // Remove single characters
+}
+
+/**
+ * Compute term frequency map for a list of tokens.
+ * @param tokens - Array of tokens
+ * @returns Map of term -> frequency count
+ */
+export function termFreq(tokens: string[]): Map<string, number> {
+	const freq = new Map<string, number>();
+	for (const token of tokens) {
+		freq.set(token, (freq.get(token) || 0) + 1);
+	}
+	return freq;
+}
+
+/**
+ * Compute Inverse Document Frequency (IDF) for a term.
+ * Uses the smoothed IDF formula: log((N - df + 0.5) / (df + 0.5) + 1)
+ * @param term - The term to compute IDF for
+ * @param allDocTokens - Array of tokenized documents (each doc is string[])
+ * @returns IDF score (higher = rarer term)
+ */
+export function idf(term: string, allDocTokens: string[][]): number {
+	const N = allDocTokens.length;
+	if (N === 0) return 0;
+
+	const docsWithTerm = allDocTokens.filter((docTokens) =>
+		docTokens.includes(term),
+	).length;
+
+	if (docsWithTerm === 0) return 0;
+
+	// Smoothed IDF formula
+	return Math.log((N - docsWithTerm + 0.5) / (docsWithTerm + 0.5) + 1);
+}
+
+/**
+ * Compute average document length across all documents.
+ * @param allDocTokens - Array of tokenized documents
+ * @returns Average number of tokens per document
+ */
+export function avgDocLength(allDocTokens: string[][]): number {
+	if (allDocTokens.length === 0) return 0;
+	const totalTokens = allDocTokens.reduce((sum, doc) => sum + doc.length, 0);
+	return totalTokens / allDocTokens.length;
+}
+
+/**
+ * Compute BM25 score for a query against a single document.
+ * @param queryTokens - Tokenized query
+ * @param docTokens - Tokenized document
+ * @param allDocTokens - All documents in corpus (for IDF calculation)
+ * @param avgDl - Average document length (precomputed for efficiency)
+ * @returns BM25 score (higher = more relevant)
+ */
+export function bm25Score(
+	queryTokens: string[],
+	docTokens: string[],
+	allDocTokens: string[][],
+	avgDl: number,
+): number {
+	const docFreq = termFreq(docTokens);
+	const docLen = docTokens.length;
+
+	let score = 0;
+	for (const term of queryTokens) {
+		const tf = docFreq.get(term) || 0;
+		if (tf === 0) continue;
+
+		const idfScore = idf(term, allDocTokens);
+		const numerator = tf * (K1 + 1);
+		const denominator = tf + K1 * (1 - B + B * (docLen / avgDl));
+		score += idfScore * (numerator / denominator);
+	}
+
+	return score;
+}
+
+/**
+ * Rank documents by BM25 relevance to a query.
+ * @param query - Search query string
+ * @param documents - Array of document strings to search
+ * @returns Array of {index, score} sorted by score descending
+ */
+export function rankDocuments(
+	query: string,
+	documents: string[],
+): Array<{ index: number; score: number }> {
+	const queryTokens = tokenize(query);
+	const allDocTokens = documents.map(tokenize);
+	const avgDl = avgDocLength(allDocTokens);
+
+	const scores = allDocTokens.map((docTokens, index) => ({
+		index,
+		score: bm25Score(queryTokens, docTokens, allDocTokens, avgDl),
+	}));
+
+	// Sort by score descending
+	return scores.sort((a, b) => b.score - a.score);
+}

--- a/src/utils/bm25.ts
+++ b/src/utils/bm25.ts
@@ -84,6 +84,11 @@ export function bm25Score(
 	allDocTokens: string[][],
 	avgDl: number,
 ): number {
+	// Guard against division by zero (e.g., all documents tokenize to [])
+	if (avgDl <= 0) {
+		return 0;
+	}
+
 	const docFreq = termFreq(docTokens);
 	const docLen = docTokens.length;
 

--- a/tests/runner/smoke.test.ts
+++ b/tests/runner/smoke.test.ts
@@ -35,7 +35,7 @@ describe("US1: Core Evaluation - End-to-End Run", () => {
 	test("should execute provider x benchmark evaluation and produce results", async () => {
 		// Arrange
 		const selection: RunSelection = {
-			providers: ["quickstart-test"],
+			providers: ["LocalBaseline"],
 			benchmarks: ["RAG-template-benchmark"],
 			concurrency: 1,
 		};
@@ -49,7 +49,7 @@ describe("US1: Core Evaluation - End-to-End Run", () => {
 		expect(output.timestamp).toBeDefined();
 
 		// Verify selections echoed back
-		expect(output.selections.providers).toEqual(["quickstart-test"]);
+		expect(output.selections.providers).toEqual(["LocalBaseline"]);
 		expect(output.selections.benchmarks).toEqual(["RAG-template-benchmark"]);
 
 		// Verify plan was generated
@@ -74,7 +74,7 @@ describe("US1: Core Evaluation - End-to-End Run", () => {
 		if (output.results.length > 0) {
 			const firstResult = output.results[0]!;
 			expect(firstResult.duration_ms).toBeGreaterThanOrEqual(0);
-			expect(firstResult.provider_name).toBe("quickstart-test");
+			expect(firstResult.provider_name).toBe("LocalBaseline");
 			expect(firstResult.benchmark_name).toBe("RAG-template-benchmark");
 		}
 	}, 30000); // 30 second timeout for actual benchmark execution
@@ -91,7 +91,7 @@ describe("US2: Capability Gating - Skip Incompatible Combinations", () => {
 
 		// Arrange - Build a run plan to check gating without execution
 		const selection: RunSelection = {
-			providers: ["quickstart-test"], // has add/retrieve/delete, NO update
+			providers: ["LocalBaseline"], // has add/retrieve/delete, NO update
 			benchmarks: ["LongMemEval"], // requires add/retrieve only
 			concurrency: 1,
 		};
@@ -145,7 +145,7 @@ describe("US3: Concurrent Execution - Parallel Case Processing", () => {
 
 		// Arrange
 		const selection: RunSelection = {
-			providers: ["quickstart-test"],
+			providers: ["LocalBaseline"],
 			benchmarks: ["RAG-template-benchmark"],
 			concurrency: 2, // Request concurrent execution
 		};
@@ -175,9 +175,9 @@ describe("US3: Concurrent Execution - Parallel Case Processing", () => {
 describe("Integration: Deterministic Ordering", () => {
 	test("should produce deterministic run plan ordering", async () => {
 		// Arrange - Use multiple benchmarks to test alphabetical sorting
-		// (Using benchmarks instead of providers since only quickstart-test is available)
+		// (Using benchmarks instead of providers since only LocalBaseline is available)
 		const selection: RunSelection = {
-			providers: ["quickstart-test"],
+			providers: ["LocalBaseline"],
 			benchmarks: ["RAG-template-benchmark", "LongMemEval"], // Two benchmarks to test sorting
 			concurrency: 1,
 		};

--- a/tests/utils/bm25.test.ts
+++ b/tests/utils/bm25.test.ts
@@ -134,6 +134,19 @@ describe("bm25Score", () => {
 		expect(bm25Score(queryTokens, docTokens, allDocs, avgDl)).toBe(0);
 	});
 
+	test("should return 0 when avgDl is 0 (all empty documents)", () => {
+		// Edge case: all documents tokenize to empty arrays
+		const queryTokens = ["test"];
+		const docTokens: string[] = [];
+		const allDocs: string[][] = [[], [], []];
+		const avgDl = avgDocLength(allDocs); // Returns 0
+
+		// Should return 0 instead of NaN
+		const score = bm25Score(queryTokens, docTokens, allDocs, avgDl);
+		expect(score).toBe(0);
+		expect(Number.isNaN(score)).toBe(false);
+	});
+
 	test("should return positive score when query matches document", () => {
 		const queryTokens = ["apple"];
 		const docTokens = ["apple", "banana"];

--- a/tests/utils/bm25.test.ts
+++ b/tests/utils/bm25.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit Tests for BM25 Scoring Algorithm
+ *
+ * Tests the BM25 (Best Matching 25) implementation used by LocalBaseline provider.
+ *
+ * @module tests/utils/bm25.test.ts
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+	tokenize,
+	termFreq,
+	idf,
+	avgDocLength,
+	bm25Score,
+	rankDocuments,
+} from "../../src/utils/bm25";
+
+// =============================================================================
+// Tokenizer Tests
+// =============================================================================
+
+describe("tokenize", () => {
+	test("should lowercase all tokens", () => {
+		expect(tokenize("Hello World")).toEqual(["hello", "world"]);
+	});
+
+	test("should remove punctuation", () => {
+		expect(tokenize("What is the capital?")).toEqual([
+			"what",
+			"is",
+			"the",
+			"capital",
+		]);
+	});
+
+	test("should handle multiple spaces", () => {
+		expect(tokenize("hello    world")).toEqual(["hello", "world"]);
+	});
+
+	test("should filter single character tokens", () => {
+		expect(tokenize("I am a test")).toEqual(["am", "test"]);
+	});
+
+	test("should handle empty string", () => {
+		expect(tokenize("")).toEqual([]);
+	});
+
+	test("should handle string with only punctuation", () => {
+		expect(tokenize("!@#$%")).toEqual([]);
+	});
+});
+
+// =============================================================================
+// Term Frequency Tests
+// =============================================================================
+
+describe("termFreq", () => {
+	test("should count term frequencies correctly", () => {
+		const tokens = ["hello", "world", "hello"];
+		const freq = termFreq(tokens);
+		expect(freq.get("hello")).toBe(2);
+		expect(freq.get("world")).toBe(1);
+	});
+
+	test("should return empty map for empty array", () => {
+		const freq = termFreq([]);
+		expect(freq.size).toBe(0);
+	});
+
+	test("should handle single token", () => {
+		const freq = termFreq(["single"]);
+		expect(freq.get("single")).toBe(1);
+	});
+});
+
+// =============================================================================
+// IDF Tests
+// =============================================================================
+
+describe("idf", () => {
+	test("should return higher score for rarer terms", () => {
+		const docs = [
+			["apple", "banana"],
+			["apple", "cherry"],
+			["apple", "date"],
+		];
+		const idfApple = idf("apple", docs); // appears in all 3 docs
+		const idfBanana = idf("banana", docs); // appears in 1 doc
+
+		expect(idfBanana).toBeGreaterThan(idfApple);
+	});
+
+	test("should return 0 for term not in any document", () => {
+		const docs = [["apple"], ["banana"]];
+		expect(idf("cherry", docs)).toBe(0);
+	});
+
+	test("should return 0 for empty corpus", () => {
+		expect(idf("anything", [])).toBe(0);
+	});
+});
+
+// =============================================================================
+// Average Document Length Tests
+// =============================================================================
+
+describe("avgDocLength", () => {
+	test("should calculate correct average", () => {
+		const docs = [
+			["a", "b", "c"], // 3 tokens
+			["d", "e"], // 2 tokens
+			["f"], // 1 token
+		];
+		expect(avgDocLength(docs)).toBe(2); // (3+2+1)/3 = 2
+	});
+
+	test("should return 0 for empty corpus", () => {
+		expect(avgDocLength([])).toBe(0);
+	});
+});
+
+// =============================================================================
+// BM25 Score Tests
+// =============================================================================
+
+describe("bm25Score", () => {
+	test("should return 0 when query has no matching terms", () => {
+		const queryTokens = ["xyz"];
+		const docTokens = ["apple", "banana"];
+		const allDocs = [docTokens];
+		const avgDl = avgDocLength(allDocs);
+
+		expect(bm25Score(queryTokens, docTokens, allDocs, avgDl)).toBe(0);
+	});
+
+	test("should return positive score when query matches document", () => {
+		const queryTokens = ["apple"];
+		const docTokens = ["apple", "banana"];
+		const allDocs = [docTokens, ["cherry", "date"]];
+		const avgDl = avgDocLength(allDocs);
+
+		expect(bm25Score(queryTokens, docTokens, allDocs, avgDl)).toBeGreaterThan(
+			0,
+		);
+	});
+
+	test("should score document with more matching terms higher", () => {
+		const queryTokens = ["capital", "france"];
+		const doc1Tokens = ["paris", "capital", "france"]; // 2 matches
+		const doc2Tokens = ["berlin", "capital", "germany"]; // 1 match
+		const allDocs = [doc1Tokens, doc2Tokens];
+		const avgDl = avgDocLength(allDocs);
+
+		const score1 = bm25Score(queryTokens, doc1Tokens, allDocs, avgDl);
+		const score2 = bm25Score(queryTokens, doc2Tokens, allDocs, avgDl);
+
+		expect(score1).toBeGreaterThan(score2);
+	});
+});
+
+// =============================================================================
+// Rank Documents Tests
+// =============================================================================
+
+describe("rankDocuments", () => {
+	test("should rank relevant documents higher", () => {
+		const query = "capital of France";
+		const documents = [
+			"Berlin is the capital of Germany",
+			"Paris is the capital of France",
+			"The weather is nice today",
+		];
+
+		const ranked = rankDocuments(query, documents);
+
+		// Document about Paris/France should rank highest
+		expect(ranked[0]?.index).toBe(1);
+		// Document about Berlin/Germany should rank second (shares "capital")
+		expect(ranked[1]?.index).toBe(0);
+		// Weather document should rank lowest
+		expect(ranked[2]?.index).toBe(2);
+	});
+
+	test("should return scores in descending order", () => {
+		const query = "test query";
+		const documents = ["first document", "test document", "query document"];
+
+		const ranked = rankDocuments(query, documents);
+
+		for (let i = 1; i < ranked.length; i++) {
+			expect(ranked[i - 1]!.score).toBeGreaterThanOrEqual(ranked[i]!.score);
+		}
+	});
+
+	test("should handle empty documents array", () => {
+		const ranked = rankDocuments("test", []);
+		expect(ranked).toEqual([]);
+	});
+
+	test("should handle query with no matches", () => {
+		const ranked = rankDocuments("xyz", ["apple banana", "cherry date"]);
+		// All scores should be 0
+		for (const result of ranked) {
+			expect(result.score).toBe(0);
+		}
+	});
+});
+
+// =============================================================================
+// Integration: RAG Benchmark Scenarios
+// =============================================================================
+
+describe("RAG Benchmark Scenarios", () => {
+	test("should match 'capital of France' query to Paris document", () => {
+		const query = "What is the capital of France?";
+		const documents = [
+			"Paris is the capital and most populous city of France. With an official estimated population of 2,102,650 residents.",
+			"France is a country primarily located in Western Europe.",
+		];
+
+		const ranked = rankDocuments(query, documents);
+
+		// Paris document should rank first
+		expect(ranked[0]?.index).toBe(0);
+		expect(ranked[0]?.score).toBeGreaterThan(0);
+	});
+
+	test("should match photosynthesis query to relevant documents", () => {
+		const query = "How does photosynthesis work in plants?";
+		const documents = [
+			"Photosynthesis is a process used by plants and other organisms to convert light energy into chemical energy.",
+			"The weather in tropical regions is typically hot and humid.",
+		];
+
+		const ranked = rankDocuments(query, documents);
+
+		// Photosynthesis document should rank first
+		expect(ranked[0]?.index).toBe(0);
+		expect(ranked[0]?.score).toBeGreaterThan(ranked[1]?.score ?? 0);
+	});
+});


### PR DESCRIPTION
## Summary

- Add BM25 lexical scoring algorithm in `src/utils/bm25.ts` for zero-dependency text retrieval
- Rename `quickstart-test` provider to `LocalBaseline` with improved retrieval
- Update all documentation and tests to reference `LocalBaseline`

## Changes

| Commit | Description |
|--------|-------------|
| `feat(utils)` | Add BM25 tokenizer, IDF, scoring functions (23 unit tests) |
| `feat(providers)` | Rename quickstart-test → LocalBaseline, integrate BM25 |
| `docs` | Update README.md, output-format.md references |
| `test` | Update smoke tests for LocalBaseline |

## Results

**Before (substring matching):** precision 0, retrieval_count 0
**After (BM25):** precision 0.5-0.6, retrieval_count 2-5

## Test Plan

- [x] BM25 unit tests pass (23 tests)
- [x] Runner smoke tests pass (4 tests)
- [x] Integration test shows retrieval working

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)