### PR TITLE
Fix provider scoping + readiness polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ bun run index.ts eval --providers LocalBaseline --benchmarks RAG-template-benchm
 # Run with concurrent execution for faster results
 bun run index.ts eval --providers LocalBaseline --benchmarks RAG-template-benchmark --concurrency 4
 
+# Run a smaller subset (useful for long benchmarks like LoCoMo/LongMemEval)
+bun run index.ts eval --providers mem0 --benchmarks LoCoMo --limit 5
+
 # Resume an interrupted run
 bun run index.ts eval --resume <run_id>
 
@@ -76,6 +79,17 @@ bun run index.ts eval \
 ```
 
 This executes up to 4 benchmark cases simultaneously per provider/benchmark combination.
+
+### Quick Iteration With `--limit`
+
+For long-running benchmarks, cap the number of cases per benchmark:
+
+```bash
+bun run index.ts eval \
+  --providers mem0 supermemory \
+  --benchmarks LoCoMo \
+  --limit 5
+```
 
 ### Understanding Output
 

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -97,6 +97,11 @@ Async memory backends don't immediately surface new memories. Set `convergence_w
 | Local database | 100-500ms |
 | Cloud with async processing | 5,000-30,000ms |
 
+If your provider can report readiness (e.g., a document status), implement
+`BaseProvider.await_convergence(scope, ingestedIds, timeoutMs)` to poll until
+newly ingested memories are retrievable. MemoryBench will prefer this hook over
+sleeping the full `convergence_wait_ms`.
+
 ## Step 2: Implement the Adapter
 
 Create `providers/my-provider/index.ts`:

--- a/docs/provider-scoping.md
+++ b/docs/provider-scoping.md
@@ -24,10 +24,12 @@ How each provider maps MemoryBench's `ScopeContext` to its native isolation mech
 
 ## Async Indexing
 
-Providers with async indexing require convergence wait times before retrieval:
+Providers with async indexing require convergence before retrieval. MemoryBench
+prefers provider-level polling via `await_convergence` when available; otherwise
+it falls back to sleeping `convergence_wait_ms`.
 
 | Provider | `convergence_wait_ms` | Notes |
 |----------|----------------------|-------|
 | LocalBaseline | 0 | Synchronous |
-| Supermemory | 10,000 | Document processing queue |
-| Mem0 | 15,000 | Fact extraction pipeline |
+| Supermemory | 30,000 | Document processing queue |
+| Mem0 | 30,000 | Fact extraction pipeline |

--- a/docs/provider-scoping.md
+++ b/docs/provider-scoping.md
@@ -18,8 +18,8 @@ How each provider maps MemoryBench's `ScopeContext` to its native isolation mech
 | Provider | Isolation Field | Mapping | Notes |
 |----------|-----------------|---------|-------|
 | **LocalBaseline** | In-memory key | `${user_id}:${run_id}:${id}` | Full scope in key |
-| **Supermemory** | `containerTag` | `memorybench_${user_id}_${run_id}` | Tag-based filtering |
-| **Mem0** | `user_id` filter | `scope.user_id` directly | Run isolation via user_id format |
+| **Supermemory** | `containerTag` | `memorybench_${run12}_${scopeHash12}` | Hash includes session_id for per-case isolation |
+| **Mem0** | `user_id` filter | `memorybench_${run12}_${scopeHash12}` | Hash includes session_id for per-case isolation |
 | **ContextualRetrieval** | DB `run_id` column | `scope.run_id` | PostgreSQL row filtering |
 
 ## Async Indexing

--- a/index.ts
+++ b/index.ts
@@ -244,6 +244,7 @@ async function handleEval(rawArgs: string[]): Promise<void> {
 	const benchmarks: string[] = [];
 	let concurrency = 1;
 	let resumeRunId: string | undefined;
+	let caseLimit: number | undefined;
 
 	// Parse arguments
 	for (let i = 0; i < rawArgs.length; i++) {
@@ -274,6 +275,16 @@ async function handleEval(rawArgs: string[]): Promise<void> {
 			if (isNaN(concurrency) || concurrency < 1) {
 				throw new Error("--concurrency must be a positive integer");
 			}
+		} else if (arg === "--limit" || arg === "-l") {
+			i++;
+			if (i >= rawArgs.length || !rawArgs[i]) {
+				throw new Error("--limit requires a value. Usage: --limit <number>");
+			}
+			const parsed = Number.parseInt(rawArgs[i]!, 10);
+			if (!Number.isFinite(parsed) || parsed < 1) {
+				throw new Error("--limit must be a positive integer");
+			}
+			caseLimit = parsed;
 		} else if (arg === "--resume") {
 			i++;
 			if (i >= rawArgs.length || !rawArgs[i]) {
@@ -313,6 +324,7 @@ async function handleEval(rawArgs: string[]): Promise<void> {
 		providers,
 		benchmarks,
 		concurrency,
+		...(caseLimit ? { case_limit: caseLimit } : {}),
 	};
 
 	// Execute runner (with resume if specified)
@@ -420,7 +432,7 @@ async function main(): Promise<void> {
 Memory Benchmark CLI
 
 Usage:
-  bun run index.ts eval --providers <provider1> [provider2...] --benchmarks <benchmark1> [benchmark2...] [--concurrency N]
+  bun run index.ts eval --providers <provider1> [provider2...] --benchmarks <benchmark1> [benchmark2...] [--concurrency N] [--limit N]
   bun run index.ts explore --run <run_id> [--port N]
   bun run index.ts list benchmarks [--json]
   bun run index.ts list providers [--json]
@@ -430,6 +442,7 @@ Commands:
     --providers, -p   Provider names to evaluate (required)
     --benchmarks, -b  Benchmark names to run (required)
     --concurrency, -c Max parallel case executions (default: 1)
+    --limit, -l       Max cases per benchmark (default: all)
 
   explore             Launch the interactive results explorer
     --run, -r         Run ID to visualize (e.g., run_1735000000000_abc)

--- a/providers/AQRAG/index.ts
+++ b/providers/AQRAG/index.ts
@@ -4,19 +4,27 @@ import { addDocument } from "./src/add";
 import { initDatabase } from "./src/db";
 import { retrieve } from "./src/retrieve";
 
-await initDatabase();
+let dbInit: Promise<void> | null = null;
+async function ensureDatabase(): Promise<void> {
+	if (!dbInit) {
+		dbInit = initDatabase();
+	}
+	await dbInit;
+}
 
 export default {
 	name: "AQRAG",
 	addContext: async (data: PreparedData) => {
+		await ensureDatabase();
 		console.log(`Processing AQRAG context: ${data.context}`);
-		console.log(`Metadata:`, data.metadata);
+		console.log("Metadata:", data.metadata);
 
 		// Process the context as a document using AQRAG (with question generation)
 		await addDocument(data.context);
 	},
 
 	searchQuery: async (query: string) => {
+		await ensureDatabase();
 		console.log(`Searching with AQRAG (question-enhanced): ${query}`);
 		const results = await retrieve(query);
 

--- a/providers/ContextualRetrieval/index.ts
+++ b/providers/ContextualRetrieval/index.ts
@@ -4,19 +4,27 @@ import { processDocument } from "./src/add";
 import { initDatabase } from "./src/db";
 import { retrieve } from "./src/retrieve";
 
-await initDatabase();
+let dbInit: Promise<void> | null = null;
+async function ensureDatabase(): Promise<void> {
+	if (!dbInit) {
+		dbInit = initDatabase();
+	}
+	await dbInit;
+}
 
 export default {
 	name: "ContextualRetrieval",
 	addContext: async (data: PreparedData) => {
+		await ensureDatabase();
 		console.log(`Processing ContextualRetrieval context: ${data.context}`);
-		console.log(`Metadata:`, data.metadata);
+		console.log("Metadata:", data.metadata);
 
 		// Process the context as a document using contextual retrieval
 		await processDocument(data.context);
 	},
 
 	searchQuery: async (query: string) => {
+		await ensureDatabase();
 		console.log(`Searching with ContextualRetrieval: ${query}`);
 		const results = await retrieve(query);
 

--- a/providers/mem0/index.ts
+++ b/providers/mem0/index.ts
@@ -574,9 +574,11 @@ const mem0Provider: BaseProvider = {
 	async reset_scope(scope: ScopeContext): Promise<boolean> {
 		const scopedUserId = getScopedUserId(scope);
 		const pageSize = 100;
-		const maxPages = 50;
+		const maxIterations = 200;
 
-		for (let page = 1; page <= maxPages; page++) {
+		// Always fetch page 1 while deleting to avoid pagination shifting (deleting items
+		// causes later pages to move up, which can skip undeleted memories).
+		for (let iteration = 0; iteration < maxIterations; iteration++) {
 			let raw: unknown;
 			try {
 				raw = await apiRequest<unknown>("/v2/memories/", {
@@ -584,7 +586,7 @@ const mem0Provider: BaseProvider = {
 					body: JSON.stringify({
 						filters: { user_id: scopedUserId },
 						version: "v2",
-						page,
+						page: 1,
 						page_size: pageSize,
 					}),
 				});
@@ -593,7 +595,7 @@ const mem0Provider: BaseProvider = {
 			}
 
 			const memories = parseListResults(raw);
-			if (memories.length === 0) break;
+			if (memories.length === 0) return true;
 
 			for (const mem of memories) {
 				if (!UUID_REGEX.test(mem.id)) continue;
@@ -605,11 +607,10 @@ const mem0Provider: BaseProvider = {
 					// Ignore delete errors during cleanup
 				}
 			}
-
-			if (memories.length < pageSize) break;
 		}
 
-		return true;
+		// If we still haven't emptied the scope after many iterations, signal failure.
+		return false;
 	},
 
 	async get_capabilities(): Promise<ProviderCapabilities> {

--- a/providers/mem0/index.ts
+++ b/providers/mem0/index.ts
@@ -16,6 +16,18 @@ import type { BaseProvider } from "../../types/provider";
 
 const API_BASE_URL = "https://api.mem0.ai";
 
+function getScopedUserId(scope: ScopeContext): string {
+	const sanitize = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, "_");
+	const runPart = sanitize(scope.run_id).slice(0, 12);
+	const sessionKey = scope.session_id ?? scope.namespace ?? "default";
+
+	const hasher = new Bun.CryptoHasher("sha256");
+	hasher.update(`${scope.user_id}|${scope.run_id}|${sessionKey}`);
+	const scopeHash = hasher.digest("hex").slice(0, 12);
+
+	return `memorybench_${runPart}_${scopeHash}`;
+}
+
 /**
  * Get API key from environment
  */
@@ -92,6 +104,141 @@ interface ListMemoryResult {
 	metadata?: Record<string, unknown>;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parseSearchResults(raw: unknown): SearchResult[] {
+	const items: unknown[] = Array.isArray(raw)
+		? raw
+		: isRecord(raw) && Array.isArray(raw.results)
+			? raw.results
+			: [];
+
+	const results: SearchResult[] = [];
+	for (const item of items) {
+		if (!isRecord(item)) continue;
+		const id = typeof item.id === "string" ? item.id : null;
+		const memory = typeof item.memory === "string" ? item.memory : null;
+		if (!id || !memory) continue;
+
+		const created_at = typeof item.created_at === "string" ? item.created_at : "";
+		const updated_at = typeof item.updated_at === "string" ? item.updated_at : "";
+		const user_id = typeof item.user_id === "string" ? item.user_id : undefined;
+		const metadata = isRecord(item.metadata) ? item.metadata : undefined;
+		const categories = Array.isArray(item.categories)
+			? item.categories.filter((c): c is string => typeof c === "string")
+			: undefined;
+		const score = typeof item.score === "number" ? item.score : undefined;
+
+		results.push({
+			id,
+			memory,
+			user_id,
+			created_at,
+			updated_at,
+			metadata,
+			categories,
+			score,
+		});
+	}
+
+	return results;
+}
+
+function parseListResults(raw: unknown): ListMemoryResult[] {
+	const items: unknown[] = Array.isArray(raw)
+		? raw
+		: isRecord(raw) && Array.isArray(raw.results)
+			? raw.results
+			: [];
+
+	const results: ListMemoryResult[] = [];
+	for (const item of items) {
+		if (!isRecord(item)) continue;
+		const id = typeof item.id === "string" ? item.id : null;
+		const memory = typeof item.memory === "string" ? item.memory : null;
+		if (!id || !memory) continue;
+
+		const created_at = typeof item.created_at === "string" ? item.created_at : "";
+		const updated_at = typeof item.updated_at === "string" ? item.updated_at : "";
+		const owner = typeof item.owner === "string" ? item.owner : undefined;
+		const metadata = isRecord(item.metadata) ? item.metadata : undefined;
+
+		results.push({ id, memory, created_at, updated_at, owner, metadata });
+	}
+
+	return results;
+}
+
+async function fetchMetadataForIds(params: {
+	apiKey: string;
+	userId: string;
+	ids: readonly string[];
+}): Promise<Map<string, Record<string, unknown>>> {
+	const apiKey = params.apiKey;
+	const userId = params.userId;
+	const ids = params.ids;
+
+	const idSet = new Set(ids.filter((id) => typeof id === "string" && id.length > 0));
+	const metadataById = new Map<string, Record<string, unknown>>();
+	if (idSet.size === 0) return metadataById;
+
+	const maxPages = 5;
+	const pageSize = 100;
+
+	for (let page = 1; page <= maxPages; page++) {
+		// Use trailing slash to avoid redirect (some servers convert POST -> GET on 301/302).
+		const resp = await fetch(`${API_BASE_URL}/v2/memories/`, {
+			method: "POST",
+			headers: {
+				Authorization: `Token ${apiKey}`,
+				"Content-Type": "application/json",
+				Accept: "application/json",
+			},
+			body: JSON.stringify({
+				filters: { user_id: userId },
+				version: "v2",
+				page,
+				page_size: pageSize,
+			}),
+		});
+
+		if (!resp.ok) {
+			break;
+		}
+
+		const raw = (await resp.json()) as unknown;
+		const memories = parseListResults(raw);
+
+		let matchedThisPage = 0;
+		for (const mem of memories) {
+			if (!idSet.has(mem.id)) continue;
+			if (isRecord(mem.metadata)) {
+				metadataById.set(mem.id, mem.metadata);
+				matchedThisPage++;
+			}
+		}
+
+		// Stop early if we've resolved all IDs
+		if (metadataById.size >= idSet.size) break;
+
+		// If this page had no results, we're done
+		if (memories.length === 0) break;
+
+		// If we didn't even see full page size, assume end
+		if (memories.length < pageSize) break;
+
+		// If we saw no matches, still continue a couple pages in case ordering differs
+		if (matchedThisPage === 0 && page >= 2) {
+			// Likely not going to find these IDs via list (or list API behavior changed)
+			break;
+		}
+	}
+
+	return metadataById;
+}
+
 /**
  * Mem0 Provider Implementation
  */
@@ -103,16 +250,22 @@ const mem0Provider: BaseProvider = {
 		content: string,
 		metadata?: Record<string, unknown>,
 	): Promise<MemoryRecord> {
+		const scopedUserId = getScopedUserId(scope);
 
 		const response = await apiRequest<AddMemoryResponse[]>("/v1/memories/", {
 			method: "POST",
 			body: JSON.stringify({
-				user_id: scope.user_id, // user_id includes run_id for scope isolation
+				user_id: scopedUserId,
 				messages: [{ role: "user", content }],
-				metadata: metadata ?? {},
+				metadata: {
+					...metadata,
+					scope_user_id: scope.user_id,
+					scope_run_id: scope.run_id,
+					scope_session_id: scope.session_id,
+					scope_namespace: scope.namespace,
+				},
 			}),
 		});
-
 
 		// Mem0 returns an array of memory events
 		const firstResult = response[0];
@@ -129,30 +282,51 @@ const mem0Provider: BaseProvider = {
 		query: string,
 		limit = 10,
 	): Promise<RetrievalItem[]> {
+		const scopedUserId = getScopedUserId(scope);
 
-		const response = await apiRequest<SearchResult[]>("/v2/memories/search/", {
+		const raw = await apiRequest<unknown>("/v2/memories/search/", {
 			method: "POST",
 			body: JSON.stringify({
 				query,
 				filters: {
-					user_id: scope.user_id, // user_id includes run_id for scope isolation
+					user_id: scopedUserId,
 				},
 				version: "v2",
 				top_k: limit,
 			}),
 		});
 
-		return response.map((result) => ({
-			record: {
-				id: result.id,
-				context: result.memory,
-				metadata: (result.metadata as Record<string, unknown>) ?? {},
-				timestamp: result.created_at
-					? new Date(result.created_at).getTime()
-					: Date.now(),
-			},
-			score: result.score ?? 0.5,
-		}));
+		const response = parseSearchResults(raw);
+
+		// Some Mem0 search output formats omit metadata. If so, backfill metadata
+		// for the retrieved IDs via the list API so retrieval metrics can still
+		// map results to benchmark session IDs.
+		const needsMetadataBackfill = response.some((r) => !isRecord(r.metadata));
+		const metadataById = needsMetadataBackfill
+			? await fetchMetadataForIds({
+					apiKey: getApiKey(),
+					userId: scopedUserId,
+					ids: response.map((r) => r.id),
+				})
+			: new Map<string, Record<string, unknown>>();
+
+		return response.map((result) => {
+			const meta =
+				(isRecord(result.metadata) ? result.metadata : metadataById.get(result.id)) ??
+				{};
+
+			return {
+				record: {
+					id: result.id,
+					context: result.memory,
+					metadata: meta,
+					timestamp: result.created_at
+						? new Date(result.created_at).getTime()
+						: Date.now(),
+				},
+				score: result.score ?? 0.5,
+			};
+		});
 	},
 
 	async delete_memory(
@@ -215,19 +389,22 @@ const mem0Provider: BaseProvider = {
 		limit = 100,
 		offset = 0,
 	): Promise<MemoryRecord[]> {
+		const scopedUserId = getScopedUserId(scope);
 		const page = Math.floor(offset / limit) + 1;
 
-		const response = await apiRequest<ListMemoryResult[]>("/v2/memories", {
+		const raw = await apiRequest<unknown>("/v2/memories/", {
 			method: "POST",
 			body: JSON.stringify({
 				filters: {
-					user_id: scope.user_id,
+					user_id: scopedUserId,
 				},
 				version: "v2",
 				page,
 				page_size: limit,
 			}),
 		});
+
+		const response = parseListResults(raw);
 
 		return response.map((doc) => ({
 			id: doc.id,
@@ -244,7 +421,7 @@ const mem0Provider: BaseProvider = {
 				retrieve_memory: true,
 				delete_memory: true,
 			},
-				optional_operations: {
+			optional_operations: {
 				update_memory: true,
 				list_memories: true,
 				reset_scope: false,

--- a/providers/mem0/index.ts
+++ b/providers/mem0/index.ts
@@ -15,6 +15,8 @@ import type {
 import type { BaseProvider } from "../../types/provider";
 
 const API_BASE_URL = "https://api.mem0.ai";
+const UUID_REGEX =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function getScopedUserId(scope: ScopeContext): string {
 	const sanitize = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, "_");
@@ -122,8 +124,10 @@ function parseSearchResults(raw: unknown): SearchResult[] {
 		const memory = typeof item.memory === "string" ? item.memory : null;
 		if (!id || !memory) continue;
 
-		const created_at = typeof item.created_at === "string" ? item.created_at : "";
-		const updated_at = typeof item.updated_at === "string" ? item.updated_at : "";
+		const created_at =
+			typeof item.created_at === "string" ? item.created_at : "";
+		const updated_at =
+			typeof item.updated_at === "string" ? item.updated_at : "";
 		const user_id = typeof item.user_id === "string" ? item.user_id : undefined;
 		const metadata = isRecord(item.metadata) ? item.metadata : undefined;
 		const categories = Array.isArray(item.categories)
@@ -160,8 +164,10 @@ function parseListResults(raw: unknown): ListMemoryResult[] {
 		const memory = typeof item.memory === "string" ? item.memory : null;
 		if (!id || !memory) continue;
 
-		const created_at = typeof item.created_at === "string" ? item.created_at : "";
-		const updated_at = typeof item.updated_at === "string" ? item.updated_at : "";
+		const created_at =
+			typeof item.created_at === "string" ? item.created_at : "";
+		const updated_at =
+			typeof item.updated_at === "string" ? item.updated_at : "";
 		const owner = typeof item.owner === "string" ? item.owner : undefined;
 		const metadata = isRecord(item.metadata) ? item.metadata : undefined;
 
@@ -180,7 +186,9 @@ async function fetchMetadataForIds(params: {
 	const userId = params.userId;
 	const ids = params.ids;
 
-	const idSet = new Set(ids.filter((id) => typeof id === "string" && id.length > 0));
+	const idSet = new Set(
+		ids.filter((id) => typeof id === "string" && id.length > 0),
+	);
 	const metadataById = new Map<string, Record<string, unknown>>();
 	if (idSet.size === 0) return metadataById;
 
@@ -237,6 +245,83 @@ async function fetchMetadataForIds(params: {
 	}
 
 	return metadataById;
+}
+
+async function fetchIdsPresentInList(params: {
+	apiKey: string;
+	userId: string;
+	ids: readonly string[];
+}): Promise<Set<string>> {
+	const apiKey = params.apiKey;
+	const userId = params.userId;
+	const ids = params.ids;
+
+	const idSet = new Set(
+		ids.filter((id) => typeof id === "string" && id.length > 0),
+	);
+	const found = new Set<string>();
+	if (idSet.size === 0) return found;
+
+	const maxPages = 5;
+	const pageSize = 100;
+
+	for (let page = 1; page <= maxPages; page++) {
+		// Use trailing slash to avoid redirect (some servers convert POST -> GET on 301/302).
+		const resp = await fetch(`${API_BASE_URL}/v2/memories/`, {
+			method: "POST",
+			headers: {
+				Authorization: `Token ${apiKey}`,
+				"Content-Type": "application/json",
+				Accept: "application/json",
+			},
+			body: JSON.stringify({
+				filters: { user_id: userId },
+				version: "v2",
+				page,
+				page_size: pageSize,
+			}),
+		});
+
+		if (!resp.ok) {
+			break;
+		}
+
+		const raw = (await resp.json()) as unknown;
+		const memories = parseListResults(raw);
+
+		for (const mem of memories) {
+			if (idSet.has(mem.id)) {
+				found.add(mem.id);
+			}
+		}
+
+		if (found.size >= idSet.size) break;
+		if (memories.length === 0) break;
+		if (memories.length < pageSize) break;
+	}
+
+	return found;
+}
+
+async function getEventStatus(params: {
+	apiKey: string;
+	eventId: string;
+}): Promise<string | null> {
+	const resp = await fetch(
+		`${API_BASE_URL}/v1/event/${encodeURIComponent(params.eventId)}/`,
+		{
+			headers: {
+				Authorization: `Token ${params.apiKey}`,
+				Accept: "application/json",
+			},
+		},
+	);
+
+	if (!resp.ok) return null;
+
+	const raw = (await resp.json()) as unknown;
+	if (!isRecord(raw)) return null;
+	return typeof raw.status === "string" ? raw.status : null;
 }
 
 /**
@@ -312,8 +397,9 @@ const mem0Provider: BaseProvider = {
 
 		return response.map((result) => {
 			const meta =
-				(isRecord(result.metadata) ? result.metadata : metadataById.get(result.id)) ??
-				{};
+				(isRecord(result.metadata)
+					? result.metadata
+					: metadataById.get(result.id)) ?? {};
 
 			return {
 				record: {
@@ -329,13 +415,79 @@ const mem0Provider: BaseProvider = {
 		});
 	},
 
+	async await_convergence(
+		scope: ScopeContext,
+		ingestedIds: string[],
+		timeoutMs: number,
+	): Promise<void> {
+		const scopedUserId = getScopedUserId(scope);
+		const apiKey = getApiKey();
+
+		const uniqueIds = Array.from(
+			new Set(
+				ingestedIds.filter((id) => typeof id === "string" && id.length > 0),
+			),
+		);
+		if (uniqueIds.length === 0) return;
+
+		const deadline = Date.now() + timeoutMs;
+		const pollIntervalMs = 1000;
+		const completed = new Set<string>();
+
+		// Determine if these look like Mem0 event IDs (async_mode) by probing one ID.
+		let useEventStatus = false;
+		try {
+			const firstId = uniqueIds[0];
+			if (!firstId) {
+				return;
+			}
+			const status = await getEventStatus({
+				apiKey,
+				eventId: firstId,
+			});
+			useEventStatus = typeof status === "string";
+			if (status === "SUCCEEDED" || status === "FAILED") {
+				completed.add(firstId);
+			}
+		} catch {
+			useEventStatus = false;
+		}
+
+		while (true) {
+			try {
+				if (useEventStatus) {
+					for (const eventId of uniqueIds) {
+						if (completed.has(eventId)) continue;
+						const status = await getEventStatus({ apiKey, eventId });
+						if (status === "SUCCEEDED" || status === "FAILED") {
+							completed.add(eventId);
+						}
+					}
+
+					if (completed.size >= uniqueIds.length) return;
+				} else {
+					const found = await fetchIdsPresentInList({
+						apiKey,
+						userId: scopedUserId,
+						ids: uniqueIds,
+					});
+					if (found.size >= uniqueIds.length) return;
+				}
+			} catch {
+				// Ignore errors and rely on timeout fallback
+			}
+
+			if (Date.now() >= deadline) return;
+			await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+		}
+	},
+
 	async delete_memory(
 		scope: ScopeContext,
 		memory_id: string,
 	): Promise<boolean> {
 		// Mem0 requires valid UUIDs for deletion - skip if not a UUID
-		const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-		if (!uuidRegex.test(memory_id)) {
+		if (!UUID_REGEX.test(memory_id)) {
 			// Not a valid UUID, skip deletion silently
 			return true;
 		}
@@ -344,7 +496,7 @@ const mem0Provider: BaseProvider = {
 				method: "DELETE",
 			});
 			return true;
-		} catch (error) {
+		} catch {
 			// Silently handle delete errors for cleanup
 			return true;
 		}
@@ -357,9 +509,10 @@ const mem0Provider: BaseProvider = {
 		metadata?: Record<string, unknown>,
 	): Promise<MemoryRecord> {
 		// Mem0 requires valid UUIDs for updates
-		const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-		if (!uuidRegex.test(memory_id)) {
-			throw new Error(`Invalid memory ID for update: ${memory_id} (must be UUID format)`);
+		if (!UUID_REGEX.test(memory_id)) {
+			throw new Error(
+				`Invalid memory ID for update: ${memory_id} (must be UUID format)`,
+			);
 		}
 
 		const response = await apiRequest<{
@@ -380,7 +533,9 @@ const mem0Provider: BaseProvider = {
 			id: response.id,
 			context: response.text,
 			metadata: (response.metadata as Record<string, unknown>) ?? {},
-			timestamp: response.updated_at ? new Date(response.updated_at).getTime() : Date.now(),
+			timestamp: response.updated_at
+				? new Date(response.updated_at).getTime()
+				: Date.now(),
 		};
 	},
 
@@ -410,8 +565,51 @@ const mem0Provider: BaseProvider = {
 			id: doc.id,
 			context: doc.memory,
 			metadata: (doc.metadata as Record<string, unknown>) ?? {},
-			timestamp: doc.created_at ? new Date(doc.created_at).getTime() : Date.now(),
+			timestamp: doc.created_at
+				? new Date(doc.created_at).getTime()
+				: Date.now(),
 		}));
+	},
+
+	async reset_scope(scope: ScopeContext): Promise<boolean> {
+		const scopedUserId = getScopedUserId(scope);
+		const pageSize = 100;
+		const maxPages = 50;
+
+		for (let page = 1; page <= maxPages; page++) {
+			let raw: unknown;
+			try {
+				raw = await apiRequest<unknown>("/v2/memories/", {
+					method: "POST",
+					body: JSON.stringify({
+						filters: { user_id: scopedUserId },
+						version: "v2",
+						page,
+						page_size: pageSize,
+					}),
+				});
+			} catch {
+				return false;
+			}
+
+			const memories = parseListResults(raw);
+			if (memories.length === 0) break;
+
+			for (const mem of memories) {
+				if (!UUID_REGEX.test(mem.id)) continue;
+				try {
+					await apiRequest(`/v1/memories/${encodeURIComponent(mem.id)}`, {
+						method: "DELETE",
+					});
+				} catch {
+					// Ignore delete errors during cleanup
+				}
+			}
+
+			if (memories.length < pageSize) break;
+		}
+
+		return true;
 	},
 
 	async get_capabilities(): Promise<ProviderCapabilities> {
@@ -424,7 +622,7 @@ const mem0Provider: BaseProvider = {
 			optional_operations: {
 				update_memory: true,
 				list_memories: true,
-				reset_scope: false,
+				reset_scope: true,
 				get_capabilities: true,
 			},
 			system_flags: {

--- a/providers/mem0/manifest.json
+++ b/providers/mem0/manifest.json
@@ -11,10 +11,10 @@
 			"retrieve_memory": true,
 			"delete_memory": true
 		},
-			"optional_operations": {
+		"optional_operations": {
 			"update_memory": true,
 			"list_memories": true,
-			"reset_scope": false,
+			"reset_scope": true,
 			"get_capabilities": true
 		},
 		"system_flags": {

--- a/providers/supermemory/index.ts
+++ b/providers/supermemory/index.ts
@@ -15,7 +15,8 @@ import type {
 } from "../../types/core";
 import type { BaseProvider } from "../../types/provider";
 
-const API_BASE_URL = process.env.SUPERMEMORY_API_URL ?? "https://api.supermemory.ai/v3";
+const API_BASE_URL =
+	process.env.SUPERMEMORY_API_URL ?? "https://api.supermemory.ai/v3";
 
 /**
  * Get API key from environment
@@ -132,6 +133,56 @@ interface ListResponse {
 	};
 }
 
+function isTerminalStatus(status: string): boolean {
+	const normalized = status.trim().toLowerCase();
+	return normalized === "done" || normalized === "failed";
+}
+
+async function fetchDocumentsForIds(params: {
+	containerTag: string;
+	ids: readonly string[];
+}): Promise<Map<string, ListDocument>> {
+	const containerTag = params.containerTag;
+	const ids = params.ids;
+
+	const idSet = new Set(
+		ids.filter((id) => typeof id === "string" && id.length > 0),
+	);
+	const found = new Map<string, ListDocument>();
+	if (idSet.size === 0) return found;
+
+	const pageSize = 100;
+	const maxPages = 10;
+
+	for (let page = 1; page <= maxPages; page++) {
+		const response = await apiRequest<ListResponse>("/documents/list", {
+			method: "POST",
+			body: JSON.stringify({
+				containerTags: [containerTag],
+				limit: pageSize,
+				page,
+				order: "desc",
+				sort: "createdAt",
+			}),
+		});
+
+		for (const doc of response.memories) {
+			if (idSet.has(doc.id)) {
+				found.set(doc.id, doc);
+			}
+			if (doc.customId && idSet.has(doc.customId)) {
+				found.set(doc.customId, doc);
+			}
+		}
+
+		if (found.size >= idSet.size) break;
+		if (response.memories.length === 0) break;
+		if (page >= response.pagination.totalPages) break;
+	}
+
+	return found;
+}
+
 /**
  * Supermemory Provider Implementation
  */
@@ -175,7 +226,7 @@ const supermemoryProvider: BaseProvider = {
 		query: string,
 		limit = 10,
 	): Promise<RetrievalItem[]> {
-		// Use containerTags for scope isolation (with 10s per-session wait, indexing should complete)
+		// Use containerTags for scope isolation
 		const containerTag = getScopeTag(scope);
 		const response = await apiRequest<SearchResponse>("/search", {
 			method: "POST",
@@ -198,6 +249,52 @@ const supermemoryProvider: BaseProvider = {
 			},
 			score: result.score,
 		}));
+	},
+
+	async await_convergence(
+		scope: ScopeContext,
+		ingestedIds: string[],
+		timeoutMs: number,
+	): Promise<void> {
+		const containerTag = getScopeTag(scope);
+		const uniqueIds = Array.from(
+			new Set(
+				ingestedIds.filter((id) => typeof id === "string" && id.length > 0),
+			),
+		);
+		if (uniqueIds.length === 0) return;
+
+		const deadline = Date.now() + timeoutMs;
+		const pollIntervalMs = 2000;
+
+		while (true) {
+			try {
+				const docsById = await fetchDocumentsForIds({
+					containerTag,
+					ids: uniqueIds,
+				});
+
+				let pending = 0;
+				for (const id of uniqueIds) {
+					const doc = docsById.get(id);
+					if (!doc) {
+						pending++;
+						continue;
+					}
+
+					if (typeof doc.status !== "string" || !isTerminalStatus(doc.status)) {
+						pending++;
+					}
+				}
+
+				if (pending === 0) return;
+			} catch {
+				// Ignore errors and rely on timeout fallback
+			}
+
+			if (Date.now() >= deadline) return;
+			await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+		}
 	},
 
 	async delete_memory(
@@ -272,6 +369,46 @@ const supermemoryProvider: BaseProvider = {
 		}));
 	},
 
+	async reset_scope(scope: ScopeContext): Promise<boolean> {
+		const containerTag = getScopeTag(scope);
+		const pageSize = 100;
+		const maxPages = 50;
+
+		for (let page = 1; page <= maxPages; page++) {
+			let response: ListResponse;
+			try {
+				response = await apiRequest<ListResponse>("/documents/list", {
+					method: "POST",
+					body: JSON.stringify({
+						containerTags: [containerTag],
+						limit: pageSize,
+						page,
+						order: "desc",
+						sort: "createdAt",
+					}),
+				});
+			} catch {
+				return false;
+			}
+
+			if (response.memories.length === 0) break;
+
+			for (const doc of response.memories) {
+				try {
+					await apiRequest(`/documents/${encodeURIComponent(doc.id)}`, {
+						method: "DELETE",
+					});
+				} catch {
+					// Ignore delete errors during cleanup
+				}
+			}
+
+			if (page >= response.pagination.totalPages) break;
+		}
+
+		return true;
+	},
+
 	async get_capabilities(): Promise<ProviderCapabilities> {
 		return {
 			core_operations: {
@@ -282,12 +419,12 @@ const supermemoryProvider: BaseProvider = {
 			optional_operations: {
 				update_memory: true,
 				list_memories: true,
-				reset_scope: false,
+				reset_scope: true,
 				get_capabilities: true,
 			},
 			system_flags: {
 				async_indexing: true, // Documents are queued for processing
-				convergence_wait_ms: 10000, // 10s wait for async indexing to complete
+				convergence_wait_ms: 30000, // Max wait for async indexing to complete
 			},
 			intelligence_flags: {
 				auto_extraction: true, // Extracts from URLs, PDFs, etc.

--- a/providers/supermemory/index.ts
+++ b/providers/supermemory/index.ts
@@ -372,9 +372,11 @@ const supermemoryProvider: BaseProvider = {
 	async reset_scope(scope: ScopeContext): Promise<boolean> {
 		const containerTag = getScopeTag(scope);
 		const pageSize = 100;
-		const maxPages = 50;
+		const maxIterations = 200;
 
-		for (let page = 1; page <= maxPages; page++) {
+		// Always fetch page 1 while deleting to avoid pagination shifting (deleting items
+		// causes later pages to move up, which can skip undeleted documents).
+		for (let iteration = 0; iteration < maxIterations; iteration++) {
 			let response: ListResponse;
 			try {
 				response = await apiRequest<ListResponse>("/documents/list", {
@@ -382,7 +384,7 @@ const supermemoryProvider: BaseProvider = {
 					body: JSON.stringify({
 						containerTags: [containerTag],
 						limit: pageSize,
-						page,
+						page: 1,
 						order: "desc",
 						sort: "createdAt",
 					}),
@@ -391,7 +393,7 @@ const supermemoryProvider: BaseProvider = {
 				return false;
 			}
 
-			if (response.memories.length === 0) break;
+			if (response.memories.length === 0) return true;
 
 			for (const doc of response.memories) {
 				try {
@@ -402,11 +404,10 @@ const supermemoryProvider: BaseProvider = {
 					// Ignore delete errors during cleanup
 				}
 			}
-
-			if (page >= response.pagination.totalPages) break;
 		}
 
-		return true;
+		// If we still haven't emptied the scope after many iterations, signal failure.
+		return false;
 	},
 
 	async get_capabilities(): Promise<ProviderCapabilities> {

--- a/providers/supermemory/index.ts
+++ b/providers/supermemory/index.ts
@@ -32,12 +32,23 @@ function getApiKey(): string {
 
 /**
  * Generate a container tag for scope isolation
- * Format: memorybench_{user_id}_{run_id}
+ * Format: memorybench_{run12}_{scopeHash12}
+ *
+ * Note: We intentionally include scope.session_id (when present) via a hash to ensure
+ * per-case isolation during concurrent execution. Using only user_id/run_id causes
+ * cross-case contamination and degraded benchmark scores.
  */
 function getScopeTag(scope: ScopeContext): string {
 	// Sanitize to alphanumeric with hyphens and underscores only
-	const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 40);
-	return `memorybench_${sanitize(scope.user_id)}_${sanitize(scope.run_id)}`;
+	const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9_-]/g, "_");
+
+	const sessionKey = scope.session_id ?? scope.namespace ?? "default";
+	const hasher = new Bun.CryptoHasher("sha256");
+	hasher.update(`${scope.user_id}|${scope.run_id}|${sessionKey}`);
+	const scopeHash = hasher.digest("hex").slice(0, 12);
+
+	const runPart = sanitize(scope.run_id).slice(0, 12);
+	return `memorybench_${runPart}_${scopeHash}`;
 }
 
 /**
@@ -145,6 +156,8 @@ const supermemoryProvider: BaseProvider = {
 					...metadata,
 					scope_user_id: scope.user_id,
 					scope_run_id: scope.run_id,
+					scope_session_id: scope.session_id,
+					scope_namespace: scope.namespace,
 				},
 			}),
 		});

--- a/providers/supermemory/manifest.json
+++ b/providers/supermemory/manifest.json
@@ -14,7 +14,7 @@
 		"optional_operations": {
 			"update_memory": true,
 			"list_memories": true,
-			"reset_scope": false,
+			"reset_scope": true,
 			"get_capabilities": true
 		},
 		"system_flags": {

--- a/src/ingestion/strategies/session-based.ts
+++ b/src/ingestion/strategies/session-based.ts
@@ -211,15 +211,20 @@ function getSessionIndicesToIngest(
 			}
 
 			// Get distributed sample of remaining indices
-			const remainingSampleSize = Math.max(sharedSampleSize - answerIndices.size, 5);
-			const sampleIndices = selectDistributedSample(totalSessions, remainingSampleSize);
+			const remainingSampleSize = Math.max(
+				sharedSampleSize - answerIndices.size,
+				5,
+			);
+			const sampleIndices = selectDistributedSample(
+				totalSessions,
+				remainingSampleSize,
+			);
 
 			// Combine answer indices with sample
 			const combined = new Set([...answerIndices, ...sampleIndices]);
 			return Array.from(combined).sort((a, b) => a - b);
 		}
 
-		case "full":
 		default: {
 			// Ingest all sessions
 			return Array.from({ length: totalSessions }, (_, i) => i);
@@ -319,7 +324,9 @@ export function createSessionBasedIngestion(
 
 				// Get answer session IDs from evidence field if configured
 				if (mergedConfig.evidenceField) {
-					const evidence = input[mergedConfig.evidenceField] as unknown[] | undefined;
+					const evidence = input[mergedConfig.evidenceField] as
+						| unknown[]
+						| undefined;
 					if (evidence && Array.isArray(evidence)) {
 						answerSessionIds = parseEvidenceToSessionIds(
 							evidence,
@@ -331,25 +338,25 @@ export function createSessionBasedIngestion(
 						| string[]
 						| undefined;
 				}
-				} else {
-					// Array format (LongMemEval-style)
-					const rawSessions = input[mergedConfig.sessionsField] as unknown;
-					if (!Array.isArray(rawSessions)) {
-						return {
-							ingestedIds: [],
-							ingestedCount: 0,
-							skippedCount: 0,
-							totalCount: 0,
-							errors: [
-								`Sessions field '${mergedConfig.sessionsField}' not found or not an array`,
-							],
-						};
-					}
-					sessions = rawSessions;
+			} else {
+				// Array format (LongMemEval-style)
+				const rawSessions = input[mergedConfig.sessionsField] as unknown;
+				if (!Array.isArray(rawSessions)) {
+					return {
+						ingestedIds: [],
+						ingestedCount: 0,
+						skippedCount: 0,
+						totalCount: 0,
+						errors: [
+							`Sessions field '${mergedConfig.sessionsField}' not found or not an array`,
+						],
+					};
+				}
+				sessions = rawSessions;
 
-					sessionIds = mergedConfig.sessionIdsField
-						? (input[mergedConfig.sessionIdsField] as string[] | undefined)
-						: undefined;
+				sessionIds = mergedConfig.sessionIdsField
+					? (input[mergedConfig.sessionIdsField] as string[] | undefined)
+					: undefined;
 				dates = mergedConfig.datesField
 					? (input[mergedConfig.datesField] as string[] | undefined)
 					: undefined;
@@ -433,7 +440,23 @@ export function createSessionBasedIngestion(
 			// Respect provider convergence time if specified
 			const convergenceWaitMs = await getConvergenceWaitMs(provider);
 			if (convergenceWaitMs > 0) {
-				await new Promise((resolve) => setTimeout(resolve, convergenceWaitMs));
+				if (typeof provider.await_convergence === "function") {
+					try {
+						await provider.await_convergence(
+							scope,
+							ingestedIds,
+							convergenceWaitMs,
+						);
+					} catch {
+						await new Promise((resolve) =>
+							setTimeout(resolve, convergenceWaitMs),
+						);
+					}
+				} else {
+					await new Promise((resolve) =>
+						setTimeout(resolve, convergenceWaitMs),
+					);
+				}
 			}
 
 			return {

--- a/src/ingestion/strategies/simple.ts
+++ b/src/ingestion/strategies/simple.ts
@@ -104,7 +104,9 @@ export function createSimpleIngestion(
 					ingestedCount: 0,
 					skippedCount: 0,
 					totalCount: 0,
-					errors: [`Content field '${mergedConfig.contentField}' not found in input`],
+					errors: [
+						`Content field '${mergedConfig.contentField}' not found in input`,
+					],
 				};
 			}
 
@@ -129,11 +131,10 @@ export function createSimpleIngestion(
 					typeof item === "string" ? item : JSON.stringify(item);
 
 				try {
-					const record = await provider.add_memory(
-						scope,
-						itemContent,
-						{ ...combinedMetadata, _index: i },
-					);
+					const record = await provider.add_memory(scope, itemContent, {
+						...combinedMetadata,
+						_index: i,
+					});
 					ingestedIds.push(record.id);
 				} catch (error) {
 					errors.push(
@@ -145,7 +146,23 @@ export function createSimpleIngestion(
 			// Respect provider convergence time if specified
 			const convergenceWaitMs = await getConvergenceWaitMs(provider);
 			if (convergenceWaitMs > 0) {
-				await new Promise((resolve) => setTimeout(resolve, convergenceWaitMs));
+				if (typeof provider.await_convergence === "function") {
+					try {
+						await provider.await_convergence(
+							scope,
+							ingestedIds,
+							convergenceWaitMs,
+						);
+					} catch {
+						await new Promise((resolve) =>
+							setTimeout(resolve, convergenceWaitMs),
+						);
+					}
+				} else {
+					await new Promise((resolve) =>
+						setTimeout(resolve, convergenceWaitMs),
+					);
+				}
 			}
 
 			return {

--- a/src/loaders/data-driven-benchmark.ts
+++ b/src/loaders/data-driven-benchmark.ts
@@ -393,9 +393,15 @@ export async function createDataDrivenBenchmark(
 						projectId: manifest.evaluation.project_id,
 					};
 
+					// Align answer synthesis context with retrieval_limit (don't cap at 5 when K is larger)
+					const answerContextLimit = Math.min(
+						retrievedContext.length,
+						manifest.query.retrieval_limit,
+					);
+
 					generatedAnswer = await generateAnswerFromContext(
 						question,
-						retrievedContext.slice(0, 5), // Use top 5 results
+						retrievedContext.slice(0, answerContextLimit),
 						judgeConfig,
 					);
 				} else {

--- a/src/metrics/retrieval.ts
+++ b/src/metrics/retrieval.ts
@@ -49,6 +49,14 @@ export function extractIds(
 	const ids: string[] = [];
 
 	for (const result of results) {
+		// Prefer explicit session ID metadata when present.
+		// This avoids relying on providers preserving "=== Session: ..." headers in stored content.
+		const metaSessionId = result.record.metadata._sessionId;
+		if (typeof metaSessionId === "string" && metaSessionId.length > 0) {
+			ids.push(metaSessionId);
+			continue;
+		}
+
 		const extractedId = extractor(result.record.context);
 		if (extractedId) {
 			ids.push(extractedId);

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -221,6 +221,7 @@ export async function executeCases(
 	benchmarkName: string,
 	runId: string,
 	concurrency: number = 1,
+	caseLimit?: number,
 	checkpoint?: Checkpoint | null,
 	writer?: ResultsWriter,
 ): Promise<{ results: RunCaseResult[]; checkpoint: Checkpoint | null }> {
@@ -233,14 +234,16 @@ export async function executeCases(
 
 	const benchmark = benchmarkEntry.benchmark;
 	const allCases = Array.from(benchmark.cases());
+	const limitedCases =
+		typeof caseLimit === "number" ? allCases.slice(0, caseLimit) : allCases;
 
 	// Filter out already-completed cases (for resume functionality)
 	const casesToRun = checkpoint
-		? allCases.filter((benchmarkCase) => {
+		? limitedCases.filter((benchmarkCase) => {
 				const caseKey = buildCaseKey(providerName, benchmarkName, benchmarkCase.id);
 				return !(caseKey in checkpoint.completed);
 		  })
-		: allCases;
+		: limitedCases;
 
 	if (concurrency === 1) {
 		// Sequential execution for concurrency=1
@@ -393,7 +396,11 @@ export async function executeRunPlan(
 		const benchmarkEntry = benchmarkRegistry.get(entry.benchmark_name);
 		if (benchmarkEntry) {
 			const caseCount = Array.from(benchmarkEntry.benchmark.cases()).length;
-			totalCases += caseCount;
+			const effectiveCount =
+				typeof selection.case_limit === "number"
+					? Math.min(caseCount, selection.case_limit)
+					: caseCount;
+			totalCases += effectiveCount;
 		}
 	}
 
@@ -435,10 +442,14 @@ export async function executeRunPlan(
 			const benchmarkEntry = benchmarkRegistry.get(entry.benchmark_name);
 			if (benchmarkEntry) {
 				const caseCount = Array.from(benchmarkEntry.benchmark.cases()).length;
+				const effectiveCount =
+					typeof selection.case_limit === "number"
+						? Math.min(caseCount, selection.case_limit)
+						: caseCount;
 				benchmarks.push({
 					name: entry.benchmark_name,
 					version: "1.0.0", // TODO: Get from benchmark metadata when available
-					case_count: caseCount,
+					case_count: effectiveCount,
 				});
 			}
 		}
@@ -469,6 +480,7 @@ export async function executeRunPlan(
 				entry.benchmark_name,
 				plan.run_id,
 				selection.concurrency,
+				selection.case_limit,
 				checkpoint,
 				writer,
 			);
@@ -528,6 +540,9 @@ export async function executeRunPlan(
 		providers: providerNames,
 		benchmarks: benchmarkNames,
 		concurrency: selection.concurrency, // Preserve original concurrency setting
+		...(typeof selection.case_limit === "number"
+			? { case_limit: selection.case_limit }
+			: {}),
 	};
 
 	return {

--- a/src/runner/types.ts
+++ b/src/runner/types.ts
@@ -27,6 +27,9 @@ export interface RunSelection {
 
 	/** Max parallel case executions (default: 1 = sequential) */
 	readonly concurrency: number;
+
+	/** Optional cap on cases per benchmark (for quick iterations) */
+	readonly case_limit?: number;
 }
 
 // =============================================================================

--- a/types/provider.ts
+++ b/types/provider.ts
@@ -141,6 +141,20 @@ export interface BaseProvider {
 	 * @returns Capability data matching manifest
 	 */
 	get_capabilities?(): Promise<ProviderCapabilities>;
+
+	/**
+	 * Wait for recently ingested memories to become retrievable.
+	 * Optional hook for providers with async indexing pipelines.
+	 *
+	 * @param scope - Execution context for test isolation
+	 * @param ingestedIds - IDs written during ingestion (best-effort; may be empty)
+	 * @param timeoutMs - Max time to wait before returning
+	 */
+	await_convergence?(
+		scope: ScopeContext,
+		ingestedIds: string[],
+		timeoutMs: number,
+	): Promise<void>;
 }
 
 // =============================================================================
@@ -279,17 +293,16 @@ export class UnsupportedOperationError extends Error {
  * ```
  */
 export function isBaseProvider(obj: unknown): obj is BaseProvider {
+	if (typeof obj !== "object" || obj === null) {
+		return false;
+	}
+
+	const record = obj as Record<string, unknown>;
 	return (
-		typeof obj === "object" &&
-		obj !== null &&
-		"name" in obj &&
-		typeof (obj as any).name === "string" &&
-		"add_memory" in obj &&
-		typeof (obj as any).add_memory === "function" &&
-		"retrieve_memory" in obj &&
-		typeof (obj as any).retrieve_memory === "function" &&
-		"delete_memory" in obj &&
-		typeof (obj as any).delete_memory === "function"
+		typeof record.name === "string" &&
+		typeof record.add_memory === "function" &&
+		typeof record.retrieve_memory === "function" &&
+		typeof record.delete_memory === "function"
 	);
 }
 
@@ -311,17 +324,16 @@ export function isBaseProvider(obj: unknown): obj is BaseProvider {
  * ```
  */
 export function isLegacyTemplate(obj: unknown): obj is TemplateType {
+	if (typeof obj !== "object" || obj === null) {
+		return false;
+	}
+
+	const record = obj as Record<string, unknown>;
 	return (
-		typeof obj === "object" &&
-		obj !== null &&
-		"name" in obj &&
-		typeof (obj as any).name === "string" &&
-		"addContext" in obj &&
-		typeof (obj as any).addContext === "function" &&
-		"searchQuery" in obj &&
-		typeof (obj as any).searchQuery === "function" &&
-		"prepareProvider" in obj &&
-		typeof (obj as any).prepareProvider === "function"
+		typeof record.name === "string" &&
+		typeof record.addContext === "function" &&
+		typeof record.searchQuery === "function" &&
+		typeof record.prepareProvider === "function"
 	);
 }
 
@@ -350,11 +362,11 @@ export function validateScopeContext(scope: unknown): ScopeContext {
 
 	if (typeof scope !== "object" || scope === null) {
 		throw new Error(
-			"Invalid ScopeContext: expected object, got " + typeof scope,
+			`Invalid ScopeContext: expected object, got ${typeof scope}`,
 		);
 	}
 
-	const obj = scope as any;
+	const obj = scope as Record<string, unknown>;
 
 	// Validate required fields
 	if (!("user_id" in obj) || typeof obj.user_id !== "string") {


### PR DESCRIPTION
## Summary
- Fixes provider scoping isolation to reduce cross-run and cross-case contamination.
- Replaces fixed sleeps with provider-aware readiness polling for async indexing (Mem0/Supermemory).
- Makes `reset_scope` deletion robust by avoiding pagination shifting during deletes.
- Improves retrieval evaluation mapping by relying on stable session metadata.
- Adds `--limit/-l` to cap benchmark cases for faster iteration.

## Details
- Mem0: polls `/v1/event/{eventId}/` when ingestion returns event IDs; falls back to list-presence polling.
- Supermemory: polls `/documents/list` until document status is terminal (`done`/`failed`).
- `reset_scope` for Mem0/Supermemory now repeatedly fetches page 1 while deleting to avoid skipping items when pages reorder.

## Testing
- Repo-wide checks currently fail due to pre-existing diagnostics and large benchmark JSONs; this PR keeps changes focused.

## Risks / Rollback
- Risk: readiness polling adds API calls (bounded + timeout-based).
- Rollback: revert this PR.
