### PR TITLE
feat: add Memvid provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .eslintcache
 .cache
 *.tsbuildinfo
+.tmp/
 
 # IntelliJ based IDEs
 .idea

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ See [docs/output-format.md](docs/output-format.md) for complete schema documenta
 | AQRAG | intelligent_memory | Adaptive query RAG with auto-extraction | ✅ Yes |
 | Supermemory | intelligent_memory | Cloud-hosted memory with document processing | ✅ SUPERMEMORY_API_KEY |
 | Mem0 | intelligent_memory | Memory with LLM extraction and graph support | ✅ MEM0_API_KEY |
+| Memvid | hybrid | Single-file `.mv2` memory layer (append-only frames) | ❌ No |
 
 ### Provider Capabilities
 
@@ -176,6 +177,7 @@ Each provider declares its capabilities in a `manifest.json`. The runner automat
 | AQRAG | ✅ | ✅ | ✅ | ❌ | ❌ | Yes | 750ms |
 | Supermemory | ✅ | ✅ | ✅ | ✅ | ✅ | Yes | 30s |
 | Mem0 | ✅ | ✅ | ✅ | ✅ | ✅ | Yes | 30s |
+| Memvid | ✅ | ✅ | ✅ | ❌ | ❌ | No | 0ms |
 
 ## Adding a Benchmark
 

--- a/benchmarks/LongMemEval/scripts/evaluate/evaluate.ts
+++ b/benchmarks/LongMemEval/scripts/evaluate/evaluate.ts
@@ -467,18 +467,18 @@ async function evaluateAll() {
 			const correct = evaluations.filter((e) => e.label === 1).length;
 			const accuracy = total > 0 ? (correct / total) * 100 : 0;
 
-			// Calculate stats by question type
-			const byQuestionType: Record<string, { correct: number; total: number }> =
-				{};
-			for (const ev of evaluations) {
-				if (!byQuestionType[ev.questionType]) {
-					byQuestionType[ev.questionType] = { correct: 0, total: 0 };
+				// Calculate stats by question type
+				const byQuestionType: Record<string, { correct: number; total: number }> =
+					{};
+				for (const ev of evaluations) {
+					const bucket =
+						byQuestionType[ev.questionType] ??
+						(byQuestionType[ev.questionType] = { correct: 0, total: 0 });
+					bucket.total++;
+					if (ev.label === 1) {
+						bucket.correct++;
+					}
 				}
-				byQuestionType[ev.questionType].total++;
-				if (ev.label === 1) {
-					byQuestionType[ev.questionType].correct++;
-				}
-			}
 
 			// Save
 			const output: any = {
@@ -528,17 +528,17 @@ async function evaluateAll() {
 	const correct = evaluations.filter((e) => e.label === 1).length;
 	const accuracy = total > 0 ? (correct / total) * 100 : 0;
 
-	// Calculate final stats by question type
-	const byQuestionType: Record<string, { correct: number; total: number }> = {};
-	for (const ev of evaluations) {
-		if (!byQuestionType[ev.questionType]) {
-			byQuestionType[ev.questionType] = { correct: 0, total: 0 };
+		// Calculate final stats by question type
+		const byQuestionType: Record<string, { correct: number; total: number }> = {};
+		for (const ev of evaluations) {
+			const bucket =
+				byQuestionType[ev.questionType] ??
+				(byQuestionType[ev.questionType] = { correct: 0, total: 0 });
+			bucket.total++;
+			if (ev.label === 1) {
+				bucket.correct++;
+			}
 		}
-		byQuestionType[ev.questionType].total++;
-		if (ev.label === 1) {
-			byQuestionType[ev.questionType].correct++;
-		}
-	}
 
 	console.log("=".repeat(60));
 	console.log("EVALUATION SUMMARY");

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@ai-sdk/google-vertex": "^3.0.74",
         "@ai-sdk/openai": "^2.0.88",
         "@anthropic-ai/vertex-sdk": "^0.14.0",
+        "@memvid/sdk": "^2.0.146",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "ai": "^5.0.44",
@@ -47,6 +48,12 @@
 
     "@anthropic-ai/vertex-sdk": ["@anthropic-ai/vertex-sdk@0.14.0", "", { "dependencies": { "@anthropic-ai/sdk": ">=0.50.3 <1", "google-auth-library": "^9.4.2" } }, "sha512-YIonqYEwQ9ILvpeOUBRBCv+91nzIs/MAZIAJ6yyJ3muwoTbZdEu54A2HcM4nRHH+Gy1vxz0FVau6aGSayXNeWQ=="],
 
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.965.0", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-jvodoJdMavvg8faN7co58vVJRO5MVep4JFPRzUNCzpJ98BDqWDk/ad045aMJcmxkLzYLS2UAnUmqjJ/tUPNlzQ=="],
+
     "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
     "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
@@ -66,6 +73,44 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
+
+    "@finom/zod-to-json-schema": ["@finom/zod-to-json-schema@3.24.11", "", { "peerDependencies": { "zod": "^4.0.14" } }, "sha512-fL656yBPiWebtfGItvtXLWrFNGlF1NcDFS0WdMQXMs9LluVg0CfT5E2oXYp0pidl0vVG53XkW55ysijNkU5/hA=="],
+
+    "@google/generative-ai": ["@google/generative-ai@0.24.1", "", {}, "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q=="],
+
+    "@langchain/core": ["@langchain/core@1.1.11", "", { "dependencies": { "@cfworker/json-schema": "^4.0.2", "ansi-styles": "^5.0.0", "camelcase": "6", "decamelize": "1.2.0", "js-tiktoken": "^1.0.12", "langsmith": ">=0.4.0 <1.0.0", "mustache": "^4.2.0", "p-queue": "^6.6.2", "uuid": "^10.0.0", "zod": "^3.25.76 || ^4" } }, "sha512-voW7j1eNdEhwBRSW947EDIwFoeRP3xabxi8YuUy6FOw3C52SthXpTr2TJrbmVJM1Q3UV7aTXB7a/q/X0Q26zoQ=="],
+
+    "@langchain/langgraph": ["@langchain/langgraph@1.0.7", "", { "dependencies": { "@langchain/langgraph-checkpoint": "^1.0.0", "@langchain/langgraph-sdk": "~1.3.1", "uuid": "^10.0.0" }, "peerDependencies": { "@langchain/core": "^1.0.1", "zod": "^3.25.32 || ^4.1.0", "zod-to-json-schema": "^3.x" }, "optionalPeers": ["zod-to-json-schema"] }, "sha512-EBGqNOWoRiEoLUaeuiXRpUM8/DE6QcwiirNyd97XhezStebBoTTilWH8CUt6S94JRGl5zwfBBRHfzotDnZS/eA=="],
+
+    "@langchain/langgraph-checkpoint": ["@langchain/langgraph-checkpoint@1.0.0", "", { "dependencies": { "uuid": "^10.0.0" }, "peerDependencies": { "@langchain/core": "^1.0.1" } }, "sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A=="],
+
+    "@langchain/langgraph-sdk": ["@langchain/langgraph-sdk@1.3.1", "", { "dependencies": { "p-queue": "^6.6.2", "p-retry": "4", "uuid": "^9.0.0" }, "peerDependencies": { "@langchain/core": "^1.0.1", "react": "^18 || ^19", "react-dom": "^18 || ^19" }, "optionalPeers": ["@langchain/core", "react", "react-dom"] }, "sha512-zTi7DZHwqtMEzapvm3I1FL4Q7OZsxtq9tTXy6s2gcCxyIU3sphqRboqytqVN7dNHLdTCLb8nXy49QKurs2MIBg=="],
+
+    "@langchain/openai": ["@langchain/openai@1.2.1", "", { "dependencies": { "js-tiktoken": "^1.0.12", "openai": "^6.10.0", "zod": "^3.25.76 || ^4" }, "peerDependencies": { "@langchain/core": "^1.0.0" } }, "sha512-eZYPhvXIwz0/8iCjj2LWqeaznQ7DZ6tBdvF+Ebv4sQW2UqJWZqRC8QIdKZgTbs8ffMWPHkSSOidYqu4XfWCNYg=="],
+
+    "@llamaindex/core": ["@llamaindex/core@0.6.22", "", { "dependencies": { "@finom/zod-to-json-schema": "3.24.11", "@llamaindex/env": "0.1.30", "@types/node": "^24.0.13", "magic-bytes.js": "^1.10.0", "zod": "^4.1.5" } }, "sha512-/BXyemkvpxMaUhOkbwJ2PTvzKjSWkL8+6QLpz/n+pk8xBwMMe1GVBgli/J57gCyi8GbrlBafBj6GaPOgWub2Eg=="],
+
+    "@llamaindex/env": ["@llamaindex/env@0.1.30", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "js-tiktoken": "^1.0.12", "pathe": "^1.1.2" }, "peerDependencies": { "@huggingface/transformers": "^3.5.0", "gpt-tokenizer": "^2.5.0" }, "optionalPeers": ["@huggingface/transformers", "gpt-tokenizer"] }, "sha512-y6kutMcCevzbmexUgz+HXf7KiZemzAoFEYSjAILfR+cG6FmYSF8XvLbGOB34Kx8mlRi7EI8rZXpezJ5qCqOyZg=="],
+
+    "@llamaindex/node-parser": ["@llamaindex/node-parser@2.0.22", "", { "dependencies": { "html-to-text": "^9.0.5" }, "peerDependencies": { "@llamaindex/core": "0.6.22", "@llamaindex/env": "0.1.30", "tree-sitter": "^0.22.0", "web-tree-sitter": "^0.24.3" } }, "sha512-uj5O89WShAAyiSZ8f8tU7hnLJ6pSmlY2a6hkAOs8odkUgT87dEqaPHpsK7w0iJdEFiob7GoLeRhv2K624FooXg=="],
+
+    "@llamaindex/openai": ["@llamaindex/openai@0.4.22", "", { "dependencies": { "openai": "^5.12.0" }, "peerDependencies": { "@llamaindex/core": "0.6.22", "@llamaindex/env": "0.1.30" } }, "sha512-jVaSscK7kyBM0wj3vceG2HPnFreSuOvkBYGFovFdS1heCyahlGDoQ1cLAUWqQ/J9Njfrt/PZTp3ICP+APl+zig=="],
+
+    "@llamaindex/workflow": ["@llamaindex/workflow@1.1.24", "", { "dependencies": { "@llamaindex/workflow-core": "^1.3.2" }, "peerDependencies": { "@llamaindex/core": "0.6.22", "@llamaindex/env": "0.1.30" } }, "sha512-VyKsbRkFlnT5dRNKbgLXQV+ZpQ+CAFgmC9LaZv6hD/fIKo6wq1wQW/ZqLZgZt569xeHgxmrXPB6KHdqn/AhPbQ=="],
+
+    "@llamaindex/workflow-core": ["@llamaindex/workflow-core@1.3.3", "", { "peerDependencies": { "@modelcontextprotocol/sdk": "^1.7.0", "hono": "^4.7.4", "next": "^15.2.2", "p-retry": "^6.2.1", "rxjs": "^7.8.2", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@modelcontextprotocol/sdk", "hono", "next", "p-retry", "rxjs", "zod"] }, "sha512-WJIcD4K2suGbNkwU5CC70jKKrA5tARba42nMs8Pou1RGzmoxqg+K+b7vyLBmiDtImR8P40YLmkayCIRVQPBmsg=="],
+
+    "@memvid/sdk": ["@memvid/sdk@2.0.146", "", { "dependencies": { "@ai-sdk/openai": "^1.0.0", "@google/generative-ai": "^0.24.0", "@langchain/langgraph": ">=0.2.0", "@langchain/openai": ">=0.3.0", "@llamaindex/core": ">=0.4.0", "@llamaindex/openai": ">=0.2.0", "ai": ">=4.0.0", "langchain": ">=0.3.0", "llamaindex": ">=0.12.0" }, "optionalDependencies": { "@memvid/sdk-darwin-arm64": "2.0.146", "@memvid/sdk-darwin-x64": "2.0.146", "@memvid/sdk-linux-x64-gnu": "2.0.146", "@memvid/sdk-win32-x64-msvc": "2.0.146" }, "peerDependencies": { "@langchain/core": ">=0.3.0", "openai": ">=1.0.0", "zod": "^3.0.0" }, "optionalPeers": ["@langchain/core", "openai", "zod"] }, "sha512-BYz3k1sao5qi8/tM4WDbIWkD03dIQChJgtIrnjvkNzP5fWedWzujQQsQk8AvnQgySM+NdVn9/kIzPapbCBWwfg=="],
+
+    "@memvid/sdk-darwin-arm64": ["@memvid/sdk-darwin-arm64@2.0.146", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+bDzL5Fp8xVUxo2pY1+Cnos2/meedsyaeZ5/k+SPqWfVrU3D+AaWyOcpaP2CMbsA8WNMpBdtnAmB7CCzp+Lfkg=="],
+
+    "@memvid/sdk-darwin-x64": ["@memvid/sdk-darwin-x64@2.0.146", "", { "os": "darwin", "cpu": "x64" }, "sha512-2hGwawKL4nnvHO42XLM7c2Bk/KW0cUbUVMYMCEOvI/M130nBQ0Qnf74JmpMfUt8puodyPq9Zr5gzjXWEBNmRdg=="],
+
+    "@memvid/sdk-linux-x64-gnu": ["@memvid/sdk-linux-x64-gnu@2.0.146", "", { "os": "linux", "cpu": "x64" }, "sha512-qy40Su8T8ICSfJgtZ4VB49Vb76GnW0kAVdm6Y0JGcmLBS2YjaAOsqwc3LquOnmivBe2cKacP/uiVitIA2xIDYw=="],
+
+    "@memvid/sdk-win32-x64-msvc": ["@memvid/sdk-win32-x64-msvc@2.0.146", "", { "os": "win32", "cpu": "x64" }, "sha512-rjELjYzqEdQIGNH6bPGyyj3cbDhyni+zg0M8zmOmU5zHKvyjGQEoX/ehUoMxgFurQ0KJlhoAZ1gZF60Ri0NfjA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -91,9 +136,21 @@
 
     "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.5", "", { "os": "win32", "cpu": "x64" }, "sha512-rtVQB9/1XK8FWJgFtsOthbPifRMYypgJwxu+pK3NHx8WvFKmq7HcPDqNr8xLzGULjQEO7eAo2aOZfONOwYz+5g=="],
 
+    "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/types": ["@smithy/types@4.11.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@types/bun": ["@types/bun@1.2.22", "", { "dependencies": { "bun-types": "1.2.22" } }, "sha512-5A/KrKos2ZcN0c6ljRSOa1fYIyCKhZfIVYeuyb4snnvomnpFqC0tTsEkdqNxbAgExV384OETQ//WAjl3XbYqQA=="],
+
+    "@types/lodash": ["@types/lodash@4.17.21", "", {}, "sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ=="],
 
     "@types/node": ["@types/node@24.5.1", "", { "dependencies": { "undici-types": "~7.12.0" } }, "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q=="],
 
@@ -101,9 +158,15 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ai": ["ai@5.0.44", "", { "dependencies": { "@ai-sdk/gateway": "1.0.23", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.9", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-l/rdoM4LcRpsRBVvZQBwSU73oNoFGlWj+PcH86QRzxDGJgZqgGItWO0QcKjBNcLDmUjGN1VYd/8J0TAXHJleRQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -115,13 +178,39 @@
 
     "bun-types": ["bun-types@1.2.22", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-hwaAu8tct/Zn6Zft4U9BsZcXkYomzpHJX28ofvx7k0Zz2HNz54n1n+tDgxoWFGB4PcFvJXJQloPhaV2eP3Q6EA=="],
 
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "console-table-printer": ["console-table-printer@2.15.0", "", { "dependencies": { "simple-wcswidth": "^1.1.2" } }, "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
+
     "dedent": ["dedent@1.7.0", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ=="],
 
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
@@ -137,9 +226,17 @@
 
     "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
 
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
+
+    "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
+
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
@@ -151,27 +248,81 @@
 
     "jws": ["jws@4.0.0", "", { "dependencies": { "jwa": "^2.0.0", "safe-buffer": "^5.0.1" } }, "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg=="],
 
+    "langchain": ["langchain@1.2.6", "", { "dependencies": { "@langchain/langgraph": "^1.0.0", "@langchain/langgraph-checkpoint": "^1.0.0", "langsmith": ">=0.4.0 <1.0.0", "uuid": "^10.0.0", "zod": "^3.25.76 || ^4" }, "peerDependencies": { "@langchain/core": "1.1.11" } }, "sha512-GoP2TZ8S0zTM32IN0W7fp4Ye7PzmlxhYjgBK2P1vtgbvUvoqN8cy0ReBTCg0Hyq5iWuPuj2ivgnzgQwyVz2LVw=="],
+
+    "langsmith": ["langsmith@0.4.5", "", { "dependencies": { "@types/uuid": "^10.0.0", "chalk": "^4.1.2", "console-table-printer": "^2.12.1", "p-queue": "^6.6.2", "semver": "^7.6.3", "uuid": "^10.0.0" }, "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/exporter-trace-otlp-proto": "*", "@opentelemetry/sdk-trace-base": "*", "openai": "*" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/exporter-trace-otlp-proto", "@opentelemetry/sdk-trace-base", "openai"] }, "sha512-9N4JSQLz6fWiZwVXaiy0erlvNHlC68EtGJZG2OX+1y9mqj7KvKSL+xJnbCFc+ky3JN8s1d6sCfyyDdi4uDdLnQ=="],
+
+    "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
+
+    "llamaindex": ["llamaindex@0.12.1", "", { "dependencies": { "@llamaindex/core": "0.6.22", "@llamaindex/env": "0.1.30", "@llamaindex/node-parser": "2.0.22", "@llamaindex/workflow": "1.1.24", "@types/lodash": "^4.17.7", "@types/node": "^24.0.13", "lodash": "^4.17.21", "magic-bytes.js": "^1.10.0" } }, "sha512-/tXXITk/iVGBycOFaDhev6dgTBIr6Ycu4FoPIt6A5JcEAiB6ujONjiV36flVXUR8JdqwMtS767XMjV+36nV4yQ=="],
+
+    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+
+    "magic-bytes.js": ["magic-bytes.js@1.12.1", "", {}, "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
+
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "openai": ["openai@6.15.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-F1Lvs5BoVvmZtzkUEVyh8mDQPPFolq4F+xdsx/DO8Hee8YF3IGAlZqUIsF+DVGhqf4aU0a3bTghsxB6OIsRy1g=="],
+
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
+
+    "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
 
     "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
 
     "react-dom": ["react-dom@19.2.3", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
+    "secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
+
+    "selderee": ["selderee@0.11.0", "", { "dependencies": { "parseley": "^0.12.0" } }, "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA=="],
+
+    "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "simple-wcswidth": ["simple-wcswidth@1.1.2", "", {}, "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
+    "tree-sitter": ["tree-sitter@0.22.4", "", { "dependencies": { "node-addon-api": "^8.3.0", "node-gyp-build": "^4.8.4" } }, "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg=="],
+
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
     "undici-types": ["undici-types@7.12.0", "", {}, "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ=="],
 
-    "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
+    "web-tree-sitter": ["web-tree-sitter@0.24.7", "", {}, "sha512-CdC/TqVFbXqR+C51v38hv6wOPatKEUGxa39scAeFSm98wIhZxAYonhRQPSMmfZ2w7JDI0zQDdzdmgtNk06/krQ=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -186,5 +337,19 @@
     "@ai-sdk/google-vertex/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
 
     "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA=="],
+
+    "@langchain/langgraph-sdk/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "@llamaindex/openai/openai": ["openai@5.23.2", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg=="],
+
+    "@memvid/sdk/@ai-sdk/openai": ["@ai-sdk/openai@1.3.24", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q=="],
+
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "@memvid/sdk/@ai-sdk/openai/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
+
+    "@memvid/sdk/@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"@ai-sdk/google-vertex": "^3.0.74",
 		"@ai-sdk/openai": "^2.0.88",
 		"@anthropic-ai/vertex-sdk": "^0.14.0",
+		"@memvid/sdk": "^2.0.146",
 		"@types/react": "^19.2.7",
 		"@types/react-dom": "^19.2.3",
 		"ai": "^5.0.44",

--- a/providers/memvid/index.ts
+++ b/providers/memvid/index.ts
@@ -1,0 +1,409 @@
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { use } from "@memvid/sdk";
+import type { FindInput, Memvid } from "@memvid/sdk";
+import type {
+	MemoryRecord,
+	ProviderCapabilities,
+	RetrievalItem,
+	ScopeContext,
+} from "../../types/core";
+import type { BaseProvider } from "../../types/provider";
+
+const STORAGE_DIR = join(process.cwd(), "checkpoints", "memvid");
+
+type HandleEntry = {
+	mv: Memvid;
+	path: string;
+	metadataByUri: Map<string, Record<string, unknown>>;
+};
+
+type FindResult = Awaited<ReturnType<Memvid["find"]>>;
+
+const handles = new Map<string, HandleEntry>();
+
+function getScopeTag(scope: ScopeContext): string {
+	const sanitize = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, "_");
+
+	const runPart = sanitize(scope.run_id).slice(0, 12);
+	const sessionKey = scope.session_id ?? scope.namespace ?? "default";
+
+	const hasher = new Bun.CryptoHasher("sha256");
+	hasher.update(`${scope.user_id}|${scope.run_id}|${sessionKey}`);
+	const scopeHash = hasher.digest("hex").slice(0, 12);
+
+	return `memorybench_${runPart}_${scopeHash}`;
+}
+
+function getFindModeFromEnv(): FindInput["mode"] {
+	const raw = process.env.MEMVID_FIND_MODE?.trim().toLowerCase();
+	if (raw === "lex" || raw === "sem" || raw === "auto") return raw;
+	return "lex";
+}
+
+function getSnippetCharsFromEnv(): number {
+	const raw = process.env.MEMVID_SNIPPET_CHARS;
+	if (!raw) return 4000;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : 4000;
+}
+
+const MEMVID_STOPWORDS = new Set([
+	"a",
+	"an",
+	"and",
+	"are",
+	"as",
+	"at",
+	"be",
+	"been",
+	"but",
+	"by",
+	"did",
+	"do",
+	"does",
+	"for",
+	"from",
+	"go",
+	"had",
+	"has",
+	"have",
+	"he",
+	"her",
+	"his",
+	"how",
+	"i",
+	"if",
+	"in",
+	"into",
+	"is",
+	"it",
+	"its",
+	"me",
+	"my",
+	"no",
+	"not",
+	"of",
+	"on",
+	"or",
+	"our",
+	"she",
+	"so",
+	"that",
+	"the",
+	"their",
+	"them",
+	"then",
+	"there",
+	"they",
+	"this",
+	"to",
+	"was",
+	"we",
+	"were",
+	"what",
+	"when",
+	"where",
+	"which",
+	"who",
+	"why",
+	"with",
+	"you",
+	"your",
+]);
+
+function rewriteQueryForMemvidLex(
+	query: string,
+	options: { force?: boolean } = {},
+): string {
+	if (!query.trim()) return query;
+
+	// If caller already uses explicit operators, assume they know what they're doing.
+	if (!options.force && /\b(AND|OR|NOT)\b/.test(query)) return query;
+
+	// Memvid's Tantivy query parser uses AND semantics by default. For natural-language
+	// questions (LoCoMo/LongMemEval), rewrite to an OR query over non-stopword tokens.
+	const tokens = query.match(/[A-Za-z0-9_]+/g) ?? [];
+	const filtered = tokens
+		.map((t) => t.trim())
+		.filter((t) => t.length > 0)
+		.filter((t) => !MEMVID_STOPWORDS.has(t.toLowerCase()));
+
+	const unique: string[] = [];
+	const seen = new Set<string>();
+	for (const token of filtered) {
+		const key = token.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		unique.push(token);
+	}
+
+	if (unique.length === 0) return query;
+	return unique.join(" OR ");
+}
+
+async function getOrCreateHandle(scope: ScopeContext): Promise<HandleEntry> {
+	const tag = getScopeTag(scope);
+	const cached = handles.get(tag);
+	if (cached) return cached;
+
+	await mkdir(STORAGE_DIR, { recursive: true });
+	const filePath = join(STORAGE_DIR, `${tag}.mv2`);
+
+	// Create is safest for benchmark isolation: each case gets a clean, empty file.
+	const mv = await use("basic", filePath, {
+		mode: "create",
+		enableLex: true,
+		enableVec: false,
+	});
+
+	const entry: HandleEntry = { mv, path: filePath, metadataByUri: new Map() };
+	handles.set(tag, entry);
+	return entry;
+}
+
+async function getHandleIfExists(
+	scope: ScopeContext,
+): Promise<HandleEntry | null> {
+	const tag = getScopeTag(scope);
+	const cached = handles.get(tag);
+	if (cached) return cached;
+
+	const filePath = join(STORAGE_DIR, `${tag}.mv2`);
+	const file = Bun.file(filePath);
+	if (!(await file.exists())) return null;
+
+	await mkdir(STORAGE_DIR, { recursive: true });
+	const mv = await use("basic", filePath, {
+		mode: "open",
+		enableLex: true,
+		enableVec: false,
+	});
+
+	const entry: HandleEntry = { mv, path: filePath, metadataByUri: new Map() };
+	handles.set(tag, entry);
+	return entry;
+}
+
+async function closeHandle(scope: ScopeContext): Promise<void> {
+	const tag = getScopeTag(scope);
+	const cached = handles.get(tag);
+	if (!cached) return;
+
+	try {
+		await cached.mv.seal();
+	} finally {
+		handles.delete(tag);
+	}
+}
+
+async function deleteFiles(filePath: string): Promise<void> {
+	await rm(filePath, { force: true }).catch(() => {});
+	await rm(`${filePath}.lock`, { force: true }).catch(() => {});
+}
+
+const memvidProvider: BaseProvider = {
+	name: "memvid",
+
+	async add_memory(
+		scope: ScopeContext,
+		content: string,
+		metadata?: Record<string, unknown>,
+	): Promise<MemoryRecord> {
+		const { mv, metadataByUri } = await getOrCreateHandle(scope);
+
+		const sessionId =
+			typeof metadata?._sessionId === "string"
+				? metadata._sessionId
+				: undefined;
+
+		const uri = `memorybench://${getScopeTag(scope)}/${crypto.randomUUID()}`;
+
+		await mv.put({
+			title: sessionId ? `Session ${sessionId}` : "MemoryBench",
+			label: "memorybench",
+			text: content,
+			metadata: metadata ?? {},
+			uri,
+		});
+
+		metadataByUri.set(uri, metadata ?? {});
+
+		return {
+			id: uri,
+			context: content,
+			metadata: metadata ?? {},
+			timestamp: Date.now(),
+		};
+	},
+
+	async retrieve_memory(
+		scope: ScopeContext,
+		query: string,
+		limit = 10,
+	): Promise<RetrievalItem[]> {
+		const entry = await getHandleIfExists(scope);
+		if (!entry) return [];
+
+		const { mv } = entry;
+		const findMode = getFindModeFromEnv();
+		const snippetChars = getSnippetCharsFromEnv();
+
+		const runFind = async (
+			q: string,
+			mode: FindInput["mode"],
+		): Promise<FindResult> => {
+			return await mv.find(q, {
+				mode,
+				k: limit,
+				snippetChars,
+			});
+		};
+
+		const tryFind = async (
+			q: string,
+			mode: FindInput["mode"],
+		): Promise<FindResult | null> => {
+			try {
+				return await runFind(q, mode);
+			} catch {
+				return null;
+			}
+		};
+
+		const rawQuery = query;
+		// Memvid's Tantivy parser treats quotes as syntax. LoCoMo questions sometimes
+		// contain unbalanced quotes, which causes hard errors. Prefer a safe rewrite
+		// for any query containing quotes.
+		const needsForcedRewrite = /["'`]/.test(rawQuery);
+		const initialQuery = needsForcedRewrite
+			? rewriteQueryForMemvidLex(rawQuery, { force: true })
+			: rawQuery;
+
+		let res: FindResult | null = await tryFind(initialQuery, findMode);
+
+		// If the configured mode errors (e.g., invalid query syntax), fall back to lex.
+		if (!res && findMode !== "lex") {
+			res = await tryFind(initialQuery, "lex");
+		}
+
+		// If the query still errors (common with unbalanced quotes), force-rewrite into
+		// Memvid-friendly OR syntax and retry.
+		if (!res) {
+			const forced = rewriteQueryForMemvidLex(rawQuery, { force: true });
+			res = await tryFind(forced, findMode);
+			if (!res && findMode !== "lex") {
+				res = await tryFind(forced, "lex");
+			}
+		}
+
+		if (!res) return [];
+
+		// If the configured mode yields no hits (common when mode=sem/auto without embeddings),
+		// fall back to lexical search to avoid false negatives in benchmarks.
+		if (res.hits.length === 0 && findMode !== "lex") {
+			const lex = await tryFind(initialQuery, "lex");
+			if (lex) {
+				res = lex;
+			}
+		}
+
+		// If we still got no hits, rewrite the query into Memvid-friendly OR syntax.
+		// Example: "When did Caroline go to the LGBTQ support group?" ->
+		// "Caroline OR LGBTQ OR support OR group"
+		if (res.hits.length === 0) {
+			const rewritten = rewriteQueryForMemvidLex(rawQuery);
+			if (rewritten !== query) {
+				const rewrittenRes =
+					(await tryFind(rewritten, findMode)) ??
+					(findMode !== "lex" ? await tryFind(rewritten, "lex") : null);
+				if (rewrittenRes) {
+					res = rewrittenRes;
+				}
+			}
+		}
+
+		const maxScore = res.hits.reduce((max, hit) => Math.max(max, hit.score), 0);
+
+		const results: RetrievalItem[] = [];
+		for (const hit of res.hits.slice(0, limit)) {
+			const storedMeta = entry.metadataByUri.get(hit.uri) ?? {};
+			const metadata: Record<string, unknown> = {
+				...storedMeta,
+				_memvid: {
+					frame_id: hit.frame_id,
+					uri: hit.uri,
+					title: hit.title,
+					tags: hit.tags,
+					labels: hit.labels,
+				},
+			};
+
+			const ts = Number.isFinite(Date.parse(hit.created_at))
+				? Date.parse(hit.created_at)
+				: Date.now();
+
+			results.push({
+				record: {
+					id: hit.uri,
+					context: hit.snippet,
+					metadata,
+					timestamp: ts,
+				},
+				score: maxScore > 0 ? hit.score / maxScore : 0,
+				match_context: hit.snippet,
+			});
+		}
+
+		return results;
+	},
+
+	async delete_memory(
+		scope: ScopeContext,
+		_memory_id: string,
+	): Promise<boolean> {
+		// Memvid frames are append-only; treat deletes as scope resets for benchmark cleanup.
+		if (!this.reset_scope) return false;
+		try {
+			return await this.reset_scope(scope);
+		} catch {
+			return false;
+		}
+	},
+
+	async reset_scope(scope: ScopeContext): Promise<boolean> {
+		const tag = getScopeTag(scope);
+		const filePath = join(STORAGE_DIR, `${tag}.mv2`);
+
+		await closeHandle(scope).catch(() => {});
+		await deleteFiles(filePath);
+		return true;
+	},
+
+	async get_capabilities(): Promise<ProviderCapabilities> {
+		return {
+			core_operations: {
+				add_memory: true,
+				retrieve_memory: true,
+				delete_memory: true,
+			},
+			optional_operations: {
+				update_memory: false,
+				list_memories: false,
+				reset_scope: true,
+				get_capabilities: true,
+			},
+			system_flags: {
+				async_indexing: false,
+				convergence_wait_ms: 0,
+			},
+			intelligence_flags: {
+				auto_extraction: true,
+				graph_support: true,
+				graph_type: "knowledge",
+			},
+		};
+	},
+};
+
+export default memvidProvider;

--- a/providers/memvid/index.ts
+++ b/providers/memvid/index.ts
@@ -398,9 +398,8 @@ const memvidProvider: BaseProvider = {
 				convergence_wait_ms: 0,
 			},
 			intelligence_flags: {
-				auto_extraction: true,
-				graph_support: true,
-				graph_type: "knowledge",
+				auto_extraction: false,
+				graph_support: false,
 			},
 		};
 	},

--- a/providers/memvid/manifest.json
+++ b/providers/memvid/manifest.json
@@ -1,0 +1,38 @@
+{
+	"manifest_version": "1",
+	"provider": {
+		"name": "memvid",
+		"type": "hybrid",
+		"version": "1.0.0"
+	},
+	"capabilities": {
+		"core_operations": {
+			"add_memory": true,
+			"retrieve_memory": true,
+			"delete_memory": true
+		},
+		"optional_operations": {
+			"update_memory": false,
+			"list_memories": false,
+			"reset_scope": true,
+			"get_capabilities": true
+		},
+		"system_flags": {
+			"async_indexing": false
+		},
+		"intelligence_flags": {
+			"auto_extraction": true,
+			"graph_support": true,
+			"graph_type": "knowledge"
+		}
+	},
+	"semantic_properties": {
+		"update_strategy": "immediate",
+		"delete_strategy": "immediate"
+	},
+	"conformance_tests": {
+		"expected_behavior": {
+			"convergence_wait_ms": 0
+		}
+	}
+}

--- a/providers/memvid/manifest.json
+++ b/providers/memvid/manifest.json
@@ -21,9 +21,8 @@
 			"async_indexing": false
 		},
 		"intelligence_flags": {
-			"auto_extraction": true,
-			"graph_support": true,
-			"graph_type": "knowledge"
+			"auto_extraction": false,
+			"graph_support": false
 		}
 	},
 	"semantic_properties": {

--- a/src/evaluation/llm-judge.ts
+++ b/src/evaluation/llm-judge.ts
@@ -75,7 +75,12 @@ function createAzureApiVersionFetch(apiVersion: string): typeof fetch {
 					: input.url;
 		const urlObj = new URL(urlString);
 		urlObj.searchParams.set("api-version", apiVersion);
-		return fetch(urlObj, init);
+
+		if (input instanceof Request) {
+			return fetch(new Request(urlObj.toString(), input), init);
+		}
+
+		return fetch(urlObj.toString(), init);
 	}) as typeof fetch;
 
 	const maybePreconnect = (

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -263,7 +263,9 @@ export async function executeCases(
 		for (let i = 0; i < casesToRun.length; i++) {
 			const benchmarkCase = casesToRun[i];
 			if (!benchmarkCase) {
-				continue;
+				throw new Error(
+					`Missing benchmark case at index ${i}/${totalCasesToRun}`,
+				);
 			}
 			const result = await executeCase(
 				providerName,

--- a/tests/ingestion/simple.test.ts
+++ b/tests/ingestion/simple.test.ts
@@ -160,6 +160,7 @@ describe("createSimpleIngestion", () => {
 					metadata: metadata ?? {},
 				};
 			},
+
 			async retrieve_memory() {
 				return [];
 			},

--- a/tests/unit/memvid-provider.test.ts
+++ b/tests/unit/memvid-provider.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import memvidProvider from "../../providers/memvid";
+import type { ScopeContext } from "../../types/core";
+
+describe("memvid provider", () => {
+	test("adds, retrieves, and resets scope", async () => {
+		const scope: ScopeContext = {
+			user_id: "test-user-memvid",
+			run_id: "test-run-memvid",
+			session_id: "memvid_unit_test",
+			namespace: "unit",
+		};
+
+		await memvidProvider.reset_scope?.(scope);
+
+		const content = "=== Session: D1 ===\n\n[USER]: Alice likes tea.";
+		const record = await memvidProvider.add_memory(scope, content, {
+			_sessionId: "D1",
+		});
+		expect(record.id.length).toBeGreaterThan(0);
+
+		const results = await memvidProvider.retrieve_memory(scope, "tea", 5);
+		expect(results.length).toBeGreaterThan(0);
+		expect(results[0]?.record.context).toContain("Alice likes tea.");
+		expect(results[0]?.record.context).toContain("=== Session: D1 ===");
+
+		const ok = await memvidProvider.reset_scope?.(scope);
+		expect(ok).toBe(true);
+
+		const after = await memvidProvider.retrieve_memory(scope, "tea", 5);
+		expect(after.length).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary
- Add a new `memvid` provider backed by single-file `.mv2` storage via `@memvid/sdk`.
- Document Memvid in the provider tables and ignore temporary `.tmp/` artifacts.
- Harden runner/test harness for provider integrations (metadata defaults, safer runner iteration, and shared Azure OpenAI fetch wrapper).

## Notes
- Memvid lexical search rewrites quoted/natural-language queries into OR-token syntax to avoid Tantivy parse errors observed in LoCoMo runs.
- Long `mem0` runs can appear to stall if the machine sleeps; use `caffeinate` for long runs.

## Testing
- `bun test`