### PR TITLE
feat: Add CRUD Semantics Benchmark (Issue #14)

### DIFF
--- a/benchmarks/CRUD-semantics/cases.ts
+++ b/benchmarks/CRUD-semantics/cases.ts
@@ -1,0 +1,197 @@
+/**
+ * CRUD Semantics Benchmark - Test Case Definitions
+ *
+ * Defines synthetic facts with unique tokens for deterministic verification.
+ * Each case uses a unique token pattern: {CATEGORY}_{UNIQUE_VALUE}_{CASE_ID}
+ *
+ * @module benchmarks/CRUD-semantics/cases
+ * @see specs/014-crud-semantics-benchmark/data-model.md
+ */
+
+import type { CRUDTestCase } from "./types";
+
+/**
+ * All CRUD test cases for the benchmark
+ *
+ * Test cases are organized by type:
+ * - write_retrieve: Verify basic write and retrieval
+ * - delete_leakage: Verify deleted data doesn't leak
+ * - update_staleness: Verify old values don't persist (capability-gated)
+ */
+export const crudTestCases: readonly CRUDTestCase[] = [
+	// =========================================================================
+	// User Story 1: Write Then Retrieve Verification (P1)
+	// =========================================================================
+
+	/**
+	 * T007: Basic fact storage with FAVORITE_COLOR token
+	 * Tests the most fundamental write/retrieve operation
+	 */
+	{
+		id: "write_retrieve_01",
+		type: "write_retrieve",
+		description: "Basic fact storage and retrieval with FAVORITE_COLOR token",
+		fact: {
+			category: "FAVORITE_COLOR",
+			initial_value: "ULTRAVIOLET_9X7K2M",
+			content_template:
+				"My favorite color is {value}. I find this color very calming and use it in my home decor.",
+		},
+		query: "What is the user's favorite color?",
+	},
+
+	/**
+	 * T008: PET_NAME token with different category
+	 * Tests retrieval with a different fact category
+	 */
+	{
+		id: "write_retrieve_02",
+		type: "write_retrieve",
+		description: "Multiple facts in one scope; retrieve specific fact",
+		setup_facts: [
+			{
+				category: "FAVORITE_MOVIE",
+				initial_value: "CITIZENKANE_1A2B3C",
+				content_template: "My favorite movie is {value}.",
+			},
+		],
+		fact: {
+			category: "PET_NAME",
+			initial_value: "FLUFFYZORAX_3B8N4P",
+			content_template:
+				"My pet's name is {value}. It's a golden retriever that loves to play fetch.",
+		},
+		query: "What is the name of the user's pet?",
+	},
+
+	/**
+	 * T009: BIRTHPLACE token - tests async convergence handling
+	 * Verifies the system handles convergence delays properly
+	 */
+	{
+		id: "write_retrieve_03",
+		type: "write_retrieve",
+		description: "Birthplace storage testing async convergence handling",
+		fact: {
+			category: "BIRTHPLACE",
+			initial_value: "QUANTUMVILLE_5H2J9R",
+			content_template:
+				"I was born in {value}. It's a small coastal town known for its beautiful sunsets.",
+		},
+		query: "Where was the user born?",
+	},
+
+	// =========================================================================
+	// User Story 2: Delete Then Leakage Verification (P2)
+	// =========================================================================
+
+	/**
+	 * T012: Adversarial exact query after delete
+	 * Tests direct query for deleted content
+	 */
+	{
+		id: "delete_leakage_01",
+		type: "delete_leakage",
+		description: "Adversarial exact query after delete - direct fact query",
+		fact: {
+			category: "SECRET_CODE",
+			initial_value: "XYLOPHONE_7K3M9W",
+			content_template:
+				"My secret code is {value}. I use this for my bank account.",
+		},
+		query: "What is the user's secret code?",
+		adversarial_queries: [
+			"Tell me about the user's secret code",
+			"What code does the user use for banking?",
+		],
+	},
+
+	/**
+	 * T013: Adversarial semantic query after delete
+	 * Tests semantic/paraphrased queries for deleted content
+	 */
+	{
+		id: "delete_leakage_02",
+		type: "delete_leakage",
+		description:
+			"Adversarial semantic query after delete - paraphrased queries",
+		fact: {
+			category: "MEDICAL_CONDITION",
+			initial_value: "ZORPLAXITIS_2N5P8Q",
+			content_template:
+				"I was diagnosed with {value}. It requires daily medication.",
+		},
+		query: "What medical condition does the user have?",
+		adversarial_queries: [
+			"What health issues affect the user?",
+			"Tell me about the user's diagnosis",
+			"What illness was the user diagnosed with?",
+		],
+	},
+
+	/**
+	 * T014: Related topic query after delete
+	 * Tests if deleted info leaks through tangentially related queries
+	 */
+	{
+		id: "delete_leakage_03",
+		type: "delete_leakage",
+		description: "Related topic query after delete - tangential queries",
+		fact: {
+			category: "SALARY_INFO",
+			initial_value: "GOLDENTHALERS_4J7R2X",
+			content_template:
+				"My annual salary is {value}. I negotiate it every year.",
+		},
+		query: "What is the user's salary?",
+		adversarial_queries: [
+			"How much money does the user make?",
+			"Tell me about the user's income",
+			"What does the user earn annually?",
+			"User financial compensation details",
+		],
+	},
+
+	// =========================================================================
+	// User Story 3: Update Then Staleness Verification (P3)
+	// =========================================================================
+
+	/**
+	 * T017: Update fact, verify old token absent
+	 * Tests basic update staleness - old value should not be returned
+	 */
+	{
+		id: "update_staleness_01",
+		type: "update_staleness",
+		description: "Update fact and verify new token present + old token absent",
+		fact: {
+			category: "FAVORITE_FOOD",
+			initial_value: "PIZZADRON_8M4K6T",
+			updated_value: "SUSHITRON_3X9W2P",
+			content_template:
+				"My favorite food is {value}. I eat it at least twice a week.",
+		},
+		query: "What is the user's favorite food?",
+		adversarial_queries: ["Is the user's favorite food PIZZADRON_8M4K6T?"],
+		requires_capability: "update_memory",
+	},
+
+	/**
+	 * T018: Update with semantic query verification
+	 * Tests update staleness with more semantic/paraphrased queries
+	 */
+	{
+		id: "update_staleness_02",
+		type: "update_staleness",
+		description: "Update with semantic query verification",
+		fact: {
+			category: "HOME_ADDRESS",
+			initial_value: "NEBULA_STREET_7R2Q5Y",
+			updated_value: "COSMOS_AVENUE_4B8J1N",
+			content_template:
+				"I live at {value}. It's in a quiet neighborhood with good schools.",
+		},
+		query: "Where does the user live?",
+		requires_capability: "update_memory",
+	},
+];

--- a/benchmarks/CRUD-semantics/index.ts
+++ b/benchmarks/CRUD-semantics/index.ts
@@ -1,0 +1,489 @@
+/**
+ * CRUD Semantics Benchmark
+ *
+ * Evaluates memory provider lifecycle semantics:
+ * - Write/Retrieve: Verify stored content is retrievable
+ * - Update Staleness: Verify old values don't persist after updates (capability-gated)
+ * - Delete Leakage: Verify deleted content doesn't leak through queries
+ *
+ * @module benchmarks/CRUD-semantics
+ * @see specs/014-crud-semantics-benchmark/spec.md
+ */
+
+import { cleanupIngested } from "../../src/ingestion";
+import type {
+	Benchmark,
+	BenchmarkCase,
+	CaseResult,
+} from "../../types/benchmark";
+import type { ScopeContext } from "../../types/core";
+import type { BaseProvider } from "../../types/provider";
+import { crudTestCases } from "./cases";
+import type { CRUDScores, CRUDTestCase } from "./types";
+import { detectToken, expandTemplate, waitForConvergence } from "./utils";
+
+/**
+ * Convert CRUDTestCase to BenchmarkCase format
+ */
+function convertToBenchmarkCase(testCase: CRUDTestCase): BenchmarkCase {
+	return {
+		id: testCase.id,
+		description: testCase.description,
+		input: {
+			type: testCase.type,
+			fact: testCase.fact,
+			setup_facts: testCase.setup_facts,
+			query: testCase.query,
+			adversarial_queries: testCase.adversarial_queries,
+			requires_capability: testCase.requires_capability,
+		},
+		expected:
+			testCase.type === "write_retrieve" ? "token_found" : "token_not_found",
+		metadata: {
+			category: testCase.fact.category,
+			case_type: testCase.type,
+		},
+	};
+}
+
+/**
+ * Default scores for initialization
+ */
+function defaultScores(): CRUDScores {
+	return {
+		write_retrieve_success: 0,
+		staleness_violation_count: 0,
+		delete_leakage_count: 0,
+		add_latency_ms: 0,
+		retrieve_latency_ms: 0,
+		update_latency_ms: 0,
+		delete_latency_ms: 0,
+	};
+}
+
+/**
+ * CRUD Semantics Benchmark implementation
+ */
+const crudBenchmark: Benchmark = {
+	meta: {
+		name: "CRUD-semantics",
+		version: "1.0.0",
+		description:
+			"Evaluates memory lifecycle semantics: write/retrieve correctness, update staleness, and delete leakage",
+		required_capabilities: ["add_memory", "retrieve_memory", "delete_memory"],
+	},
+
+	cases() {
+		return crudTestCases.map(convertToBenchmarkCase);
+	},
+
+	async run_case(
+		provider: BaseProvider,
+		scope: ScopeContext,
+		benchmarkCase: BenchmarkCase,
+	): Promise<CaseResult> {
+		const start = performance.now();
+		const ingestedIds: string[] = [];
+		const scores = { ...defaultScores() };
+		const artifacts: Record<string, unknown> = {};
+
+		try {
+			const input = benchmarkCase.input as {
+				type: string;
+				fact: {
+					category: string;
+					initial_value: string;
+					updated_value?: string;
+					content_template: string;
+					verification_query?: string;
+				};
+				setup_facts?: Array<{
+					category: string;
+					initial_value: string;
+					updated_value?: string;
+					content_template: string;
+					verification_query?: string;
+				}>;
+				query: string;
+				adversarial_queries?: string[];
+				requires_capability?: string;
+			};
+
+			// Check capability gating for update_memory
+			if (input.requires_capability === "update_memory") {
+				if (typeof provider.update_memory !== "function") {
+					return {
+						case_id: benchmarkCase.id,
+						status: "skip",
+						scores,
+						duration_ms: performance.now() - start,
+						artifacts: {
+							...artifacts,
+							skip_reason: "Provider does not support update_memory",
+						},
+					};
+				}
+			}
+
+			// Execute based on case type
+			switch (input.type) {
+				case "write_retrieve":
+					return await runWriteRetrieve(
+						provider,
+						scope,
+						benchmarkCase,
+						input,
+						ingestedIds,
+						scores,
+						artifacts,
+						start,
+					);
+
+				case "delete_leakage":
+					return await runDeleteLeakage(
+						provider,
+						scope,
+						benchmarkCase,
+						input,
+						ingestedIds,
+						scores,
+						artifacts,
+						start,
+					);
+
+				case "update_staleness":
+					return await runUpdateStaleness(
+						provider,
+						scope,
+						benchmarkCase,
+						input,
+						ingestedIds,
+						scores,
+						artifacts,
+						start,
+					);
+
+				default:
+					throw new Error(`Unknown case type: ${input.type}`);
+			}
+		} catch (error) {
+			return {
+				case_id: benchmarkCase.id,
+				status: "error",
+				scores,
+				duration_ms: performance.now() - start,
+				error: {
+					message: error instanceof Error ? error.message : String(error),
+					stack: error instanceof Error ? error.stack : undefined,
+				},
+				artifacts,
+			};
+		} finally {
+			// Cleanup ingested records
+			if (ingestedIds.length > 0) {
+				await cleanupIngested(provider, scope, ingestedIds).catch(() => {
+					// Ignore cleanup errors
+				});
+			}
+		}
+	},
+};
+
+// =============================================================================
+// Case Type Implementations
+// =============================================================================
+
+/**
+ * Run a write_retrieve test case
+ */
+async function runWriteRetrieve(
+	provider: BaseProvider,
+	scope: ScopeContext,
+	benchmarkCase: BenchmarkCase,
+	input: {
+		fact: {
+			initial_value: string;
+			content_template: string;
+			verification_query?: string;
+		};
+		setup_facts?: Array<{
+			category: string;
+			initial_value: string;
+			content_template: string;
+			verification_query?: string;
+		}>;
+		query: string;
+	},
+	ingestedIds: string[],
+	scores: CRUDScores,
+	artifacts: Record<string, unknown>,
+	start: number,
+): Promise<CaseResult> {
+	const mutableScores = { ...scores };
+	const mutableArtifacts = { ...artifacts };
+
+	// Step 1: Add optional setup facts first (multiple facts in same scope)
+	if (input.setup_facts) {
+		for (const fact of input.setup_facts) {
+			const content = expandTemplate(fact.content_template, fact.initial_value);
+			const record = await provider.add_memory(scope, content);
+			ingestedIds.push(record.id);
+		}
+	}
+
+	// Step 2: Add primary memory
+	const content = expandTemplate(
+		input.fact.content_template,
+		input.fact.initial_value,
+	);
+	const addStart = performance.now();
+	const record = await provider.add_memory(scope, content);
+	mutableScores.add_latency_ms = performance.now() - addStart;
+	ingestedIds.push(record.id);
+	mutableArtifacts.ingested_ids = [...ingestedIds];
+
+	// Step 3: Wait for convergence
+	await waitForConvergence(provider, scope, ingestedIds);
+
+	// Step 4: Retrieve and verify token
+	const verificationQuery = input.fact.verification_query ?? input.query;
+	const retrieveStart = performance.now();
+	const results = await provider.retrieve_memory(scope, verificationQuery, 5);
+	mutableScores.retrieve_latency_ms = performance.now() - retrieveStart;
+
+	// Step 5: Token detection
+	const detection = detectToken(results, input.fact.initial_value);
+	mutableScores.write_retrieve_success = detection.found ? 1 : 0;
+	mutableArtifacts.expected_token = input.fact.initial_value;
+	mutableArtifacts.token_found = detection.found;
+	mutableArtifacts.verification_query = verificationQuery;
+
+	if (detection.found) {
+		mutableArtifacts.token_found_in = detection.found_in_indices.map(
+			(i) => results[i]?.record.id ?? `index_${i}`,
+		);
+	}
+
+	// Store retrieve results for debugging
+	mutableArtifacts.retrieve_results = results.map((r) => ({
+		id: r.record.id,
+		context: r.record.context.substring(0, 200), // Truncate for readability
+		score: r.score,
+	}));
+
+	return {
+		case_id: benchmarkCase.id,
+		status: detection.found ? "pass" : "fail",
+		scores: mutableScores,
+		duration_ms: performance.now() - start,
+		artifacts: mutableArtifacts,
+	};
+}
+
+/**
+ * Run a delete_leakage test case
+ */
+async function runDeleteLeakage(
+	provider: BaseProvider,
+	scope: ScopeContext,
+	benchmarkCase: BenchmarkCase,
+	input: {
+		fact: { initial_value: string; content_template: string };
+		query: string;
+		adversarial_queries?: string[];
+	},
+	ingestedIds: string[],
+	scores: CRUDScores,
+	artifacts: Record<string, unknown>,
+	start: number,
+): Promise<CaseResult> {
+	const mutableScores = { ...scores };
+	const mutableArtifacts = { ...artifacts };
+
+	// Step 1: Add memory
+	const content = expandTemplate(
+		input.fact.content_template,
+		input.fact.initial_value,
+	);
+	const addStart = performance.now();
+	const record = await provider.add_memory(scope, content);
+	mutableScores.add_latency_ms = performance.now() - addStart;
+	const recordId = record.id;
+	mutableArtifacts.ingested_ids = [recordId];
+
+	// Step 2: Wait for convergence
+	await waitForConvergence(provider, scope, [recordId]);
+
+	// Step 3: Delete the memory
+	const deleteStart = performance.now();
+	await provider.delete_memory(scope, recordId);
+	mutableScores.delete_latency_ms = performance.now() - deleteStart;
+
+	// Don't add to ingestedIds since we already deleted it
+	// Clear from cleanup list as it's already deleted
+
+	// Step 4: Wait for delete to propagate
+	await waitForConvergence(provider, scope, []);
+
+	// Step 5: Run adversarial queries and count leaks
+	// Include exact deleted content to satisfy the acceptance scenario.
+	const exactContentQuery = content;
+	const tokenQuery = input.fact.initial_value;
+	const queries = [
+		input.query,
+		tokenQuery,
+		exactContentQuery,
+		...(input.adversarial_queries ?? []),
+	];
+	let leakCount = 0;
+
+	for (const query of queries) {
+		const retrieveStart = performance.now();
+		const results = await provider.retrieve_memory(scope, query, 5);
+		mutableScores.retrieve_latency_ms = Math.max(
+			mutableScores.retrieve_latency_ms,
+			performance.now() - retrieveStart,
+		);
+
+		const detection = detectToken(results, input.fact.initial_value);
+		if (detection.found) {
+			leakCount++;
+		}
+	}
+
+	mutableScores.delete_leakage_count = leakCount;
+	mutableArtifacts.expected_token = input.fact.initial_value;
+	mutableArtifacts.token_found = leakCount > 0;
+	mutableArtifacts.verification_query = queries.join(" | ");
+
+	return {
+		case_id: benchmarkCase.id,
+		status: leakCount === 0 ? "pass" : "fail",
+		scores: mutableScores,
+		duration_ms: performance.now() - start,
+		artifacts: mutableArtifacts,
+	};
+}
+
+/**
+ * Run an update_staleness test case
+ */
+async function runUpdateStaleness(
+	provider: BaseProvider,
+	scope: ScopeContext,
+	benchmarkCase: BenchmarkCase,
+	input: {
+		fact: {
+			initial_value: string;
+			updated_value?: string;
+			content_template: string;
+			verification_query?: string;
+		};
+		query: string;
+		adversarial_queries?: string[];
+	},
+	ingestedIds: string[],
+	scores: CRUDScores,
+	artifacts: Record<string, unknown>,
+	start: number,
+): Promise<CaseResult> {
+	const mutableScores = { ...scores };
+	const mutableArtifacts = { ...artifacts };
+
+	// This should only be called if update_memory exists (checked earlier)
+	if (typeof provider.update_memory !== "function") {
+		return {
+			case_id: benchmarkCase.id,
+			status: "skip",
+			scores: mutableScores,
+			duration_ms: performance.now() - start,
+			artifacts: { skip_reason: "Provider does not support update_memory" },
+		};
+	}
+
+	const updatedValue = input.fact.updated_value ?? `UPDATED_${Date.now()}`;
+
+	// Step 1: Add initial memory
+	const initialContent = expandTemplate(
+		input.fact.content_template,
+		input.fact.initial_value,
+	);
+	const addStart = performance.now();
+	const record = await provider.add_memory(scope, initialContent);
+	mutableScores.add_latency_ms = performance.now() - addStart;
+	ingestedIds.push(record.id);
+	mutableArtifacts.ingested_ids = [...ingestedIds];
+
+	// Step 2: Wait for convergence
+	await waitForConvergence(provider, scope, ingestedIds);
+
+	// Step 3: Update to new value
+	const updatedContent = expandTemplate(
+		input.fact.content_template,
+		updatedValue,
+	);
+	const updateStart = performance.now();
+	await provider.update_memory(scope, record.id, updatedContent);
+	mutableScores.update_latency_ms = performance.now() - updateStart;
+
+	// Step 4: Wait for update to propagate
+	await waitForConvergence(provider, scope, ingestedIds);
+
+	// Step 5: Retrieve and check for staleness
+	const verificationQueries = [
+		input.fact.verification_query ?? input.query,
+		...(input.adversarial_queries ?? []),
+	];
+
+	let stalenessViolations = 0;
+	let newTokenFound = false;
+	const allResults: Array<{
+		query: string;
+		results: Array<{ id: string; context: string; score: number }>;
+	}> = [];
+
+	for (const query of verificationQueries) {
+		const retrieveStart = performance.now();
+		const results = await provider.retrieve_memory(scope, query, 5);
+		mutableScores.retrieve_latency_ms = Math.max(
+			mutableScores.retrieve_latency_ms,
+			performance.now() - retrieveStart,
+		);
+
+		const oldTokenDetection = detectToken(results, input.fact.initial_value);
+		const newTokenDetection = detectToken(results, updatedValue);
+
+		if (oldTokenDetection.found) stalenessViolations++;
+		if (newTokenDetection.found) newTokenFound = true;
+
+		allResults.push({
+			query,
+			results: results.map((r) => ({
+				id: r.record.id,
+				context: r.record.context.substring(0, 200),
+				score: r.score,
+			})),
+		});
+	}
+
+	mutableScores.staleness_violation_count = stalenessViolations;
+	mutableScores.write_retrieve_success = newTokenFound ? 1 : 0;
+
+	mutableArtifacts.expected_token = updatedValue;
+	mutableArtifacts.token_found = newTokenFound;
+	mutableArtifacts.verification_query = verificationQueries.join(" | ");
+	mutableArtifacts.retrieve_results = allResults.flatMap((q) => q.results);
+
+	// Pass only if the new token is present and there are no staleness violations
+	const status = newTokenFound && stalenessViolations === 0 ? "pass" : "fail";
+
+	return {
+		case_id: benchmarkCase.id,
+		status,
+		scores: mutableScores,
+		duration_ms: performance.now() - start,
+		artifacts: mutableArtifacts,
+	};
+}
+
+export default crudBenchmark;

--- a/benchmarks/CRUD-semantics/index.ts
+++ b/benchmarks/CRUD-semantics/index.ts
@@ -309,7 +309,11 @@ async function runDeleteLeakage(
 	const record = await provider.add_memory(scope, content);
 	mutableScores.add_latency_ms = performance.now() - addStart;
 	const recordId = record.id;
-	mutableArtifacts.ingested_ids = [recordId];
+	mutableArtifacts.ingested_id = recordId;
+
+	// Add to cleanup list BEFORE deleting - ensures cleanup runs if delete fails
+	// (cleanupIngested handles already-deleted IDs gracefully)
+	ingestedIds.push(recordId);
 
 	// Step 2: Wait for convergence
 	await waitForConvergence(provider, scope, [recordId]);
@@ -318,9 +322,6 @@ async function runDeleteLeakage(
 	const deleteStart = performance.now();
 	await provider.delete_memory(scope, recordId);
 	mutableScores.delete_latency_ms = performance.now() - deleteStart;
-
-	// Don't add to ingestedIds since we already deleted it
-	// Clear from cleanup list as it's already deleted
 
 	// Step 4: Wait for delete to propagate
 	await waitForConvergence(provider, scope, []);

--- a/benchmarks/CRUD-semantics/types.ts
+++ b/benchmarks/CRUD-semantics/types.ts
@@ -1,0 +1,148 @@
+/**
+ * CRUD Semantics Benchmark - Local Type Definitions
+ *
+ * These types define the interface contracts for the CRUD Semantics benchmark.
+ * They mirror the contracts in specs/014-crud-semantics-benchmark/contracts/benchmark-types.ts
+ *
+ * @module benchmarks/CRUD-semantics/types
+ * @see specs/014-crud-semantics-benchmark/data-model.md
+ */
+
+// =============================================================================
+// Test Case Types
+// =============================================================================
+
+/**
+ * Types of CRUD test cases supported by the benchmark
+ */
+export type CRUDCaseType =
+	| "write_retrieve"
+	| "update_staleness"
+	| "delete_leakage";
+
+/**
+ * Synthetic fact with unique tokens for deterministic verification
+ */
+export interface SyntheticFact {
+	/** Fact category (e.g., "FAVORITE_COLOR", "PET_NAME") */
+	readonly category: string;
+
+	/** Initial unique token (e.g., "ULTRAVIOLET_123") */
+	readonly initial_value: string;
+
+	/** Updated token for update tests (e.g., "CRIMSON_456") */
+	readonly updated_value?: string;
+
+	/** Template for memory content with {value} placeholder */
+	readonly content_template: string;
+
+	/** Query to validate this fact (optional; falls back to case.query) */
+	readonly verification_query?: string;
+
+	/** Optional metadata markers for fallback verification */
+	readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * A single CRUD test case definition
+ */
+export interface CRUDTestCase {
+	/** Unique case identifier (e.g., "write_retrieve_01") */
+	readonly id: string;
+
+	/** Type of CRUD operation being tested */
+	readonly type: CRUDCaseType;
+
+	/** Human-readable description */
+	readonly description?: string;
+
+	/** The synthetic fact to test */
+	readonly fact: SyntheticFact;
+
+	/** Optional additional facts to pre-load into the same scope */
+	readonly setup_facts?: readonly SyntheticFact[];
+
+	/** Primary verification query */
+	readonly query: string;
+
+	/** Additional queries (used for delete leakage and update staleness checks) */
+	readonly adversarial_queries?: readonly string[];
+
+	/** Optional capability gate (e.g., "update_memory") */
+	readonly requires_capability?: string;
+}
+
+// =============================================================================
+// Result Types
+// =============================================================================
+
+/**
+ * Metrics emitted by CRUD benchmark cases
+ */
+export interface CRUDScores {
+	/** 1 if initial token found after write, 0 otherwise */
+	readonly write_retrieve_success: number;
+
+	/** Count of queries returning old token after update */
+	readonly staleness_violation_count: number;
+
+	/** Count of queries returning deleted token */
+	readonly delete_leakage_count: number;
+
+	/** Time for add_memory operation in milliseconds */
+	readonly add_latency_ms: number;
+
+	/** Time for retrieve_memory operation in milliseconds */
+	readonly retrieve_latency_ms: number;
+
+	/** Time for update_memory operation (0 if skipped) */
+	readonly update_latency_ms: number;
+
+	/** Time for delete_memory operation in milliseconds */
+	readonly delete_latency_ms: number;
+}
+
+/**
+ * Debug artifacts for failed cases
+ */
+export interface CRUDArtifacts {
+	/** Memory IDs returned from add_memory (including any setup facts) */
+	readonly ingested_ids?: readonly string[];
+
+	/** Which results contained the expected token */
+	readonly token_found_in?: readonly string[];
+
+	/** Raw query used for verification */
+	readonly verification_query?: string;
+
+	/** Token that was searched for */
+	readonly expected_token?: string;
+
+	/** Whether token was found (for debugging) */
+	readonly token_found?: boolean;
+
+	/** Raw retrieval results for debugging */
+	readonly retrieve_results?: readonly {
+		id: string;
+		context: string;
+		score: number;
+	}[];
+}
+
+// =============================================================================
+// Utility Types
+// =============================================================================
+
+/**
+ * Result of token detection in retrieval results
+ */
+export interface TokenDetectionResult {
+	/** Whether the token was found */
+	readonly found: boolean;
+
+	/** Which result indices contained the token */
+	readonly found_in_indices: readonly number[];
+
+	/** Total number of results checked */
+	readonly total_results: number;
+}

--- a/benchmarks/CRUD-semantics/utils.ts
+++ b/benchmarks/CRUD-semantics/utils.ts
@@ -1,0 +1,150 @@
+/**
+ * CRUD Semantics Benchmark - Utility Functions
+ *
+ * Provides token detection and convergence wait helpers for the benchmark.
+ *
+ * @module benchmarks/CRUD-semantics/utils
+ * @see specs/014-crud-semantics-benchmark/research.md
+ */
+
+import type { RetrievalItem } from "../../types/core";
+import type { BaseProvider } from "../../types/provider";
+import type { TokenDetectionResult } from "./types";
+
+// =============================================================================
+// Token Detection
+// =============================================================================
+
+/**
+ * Detect if a unique token is present in retrieval results.
+ *
+ * Uses case-insensitive matching to handle providers that may normalize text.
+ * This is the primary verification strategy for CRUD semantics - synthetic
+ * tokens like "ULTRAVIOLET_123" cannot be paraphrased by auto-extraction.
+ *
+ * @param results - Array of retrieval items from provider.retrieve_memory
+ * @param token - The unique token to search for (e.g., "ULTRAVIOLET_123")
+ * @returns Detection result with found status and indices
+ *
+ * @example
+ * ```typescript
+ * const results = await provider.retrieve_memory(scope, "What is the favorite color?", 5);
+ * const detection = detectToken(results, "ULTRAVIOLET_123");
+ * if (detection.found) {
+ *   console.log(`Token found in ${detection.found_in_indices.length} results`);
+ * }
+ * ```
+ */
+export function detectToken(
+	results: RetrievalItem[],
+	token: string,
+): TokenDetectionResult {
+	const normalizedToken = token.toLowerCase();
+	const foundIndices: number[] = [];
+
+	for (let i = 0; i < results.length; i++) {
+		const result = results[i];
+		if (result?.record.context.toLowerCase().includes(normalizedToken)) {
+			foundIndices.push(i);
+		}
+	}
+
+	return {
+		found: foundIndices.length > 0,
+		found_in_indices: foundIndices,
+		total_results: results.length,
+	};
+}
+
+/**
+ * Expand a content template with a value.
+ *
+ * Replaces {value} placeholder with the actual token value.
+ *
+ * @param template - Template string with {value} placeholder
+ * @param value - The value to insert
+ * @returns Expanded content string
+ *
+ * @example
+ * ```typescript
+ * const content = expandTemplate("My favorite color is {value}", "ULTRAVIOLET_123");
+ * // Returns: "My favorite color is ULTRAVIOLET_123"
+ * ```
+ */
+export function expandTemplate(template: string, value: string): string {
+	return template.replace("{value}", value);
+}
+
+// =============================================================================
+// Convergence Wait Helper
+// =============================================================================
+
+/**
+ * Get the convergence wait time from a provider's capabilities.
+ *
+ * For async providers (like Supermemory), this returns the time to wait
+ * after write operations before reads are guaranteed to reflect changes.
+ *
+ * Pattern from benchmarks/RAG-template-benchmark/benchmark.ts:19-31
+ *
+ * @param provider - The memory provider
+ * @returns Wait time in milliseconds (0 if not async or unknown)
+ */
+export async function getConvergenceWaitMs(
+	provider: BaseProvider,
+): Promise<number> {
+	if (!provider.get_capabilities) {
+		return 0;
+	}
+
+	try {
+		const capabilities = await provider.get_capabilities();
+		const waitMs = capabilities?.system_flags?.convergence_wait_ms ?? 0;
+		return typeof waitMs === "number" && waitMs > 0 ? waitMs : 0;
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Wait for provider convergence after a write operation.
+ *
+ * Uses provider.await_convergence if available, otherwise falls back to
+ * a simple setTimeout with the convergence_wait_ms from capabilities.
+ *
+ * @param provider - The memory provider
+ * @param scope - Execution context for the operation
+ * @param ingestedIds - IDs of recently written records
+ * @param waitMs - Override wait time (uses provider capabilities if 0)
+ */
+export async function waitForConvergence(
+	provider: BaseProvider,
+	scope: { user_id: string; run_id: string; session_id?: string },
+	ingestedIds: string[],
+	waitMs?: number,
+): Promise<void> {
+	const convergenceWaitMs = waitMs ?? (await getConvergenceWaitMs(provider));
+
+	if (convergenceWaitMs <= 0) {
+		return;
+	}
+
+	// If we don't have IDs to poll for, we still need to respect the provider's
+	// convergence window (e.g., for delete propagation). In that case, fall back
+	// to a simple sleep.
+	if (ingestedIds.length === 0) {
+		await new Promise((resolve) => setTimeout(resolve, convergenceWaitMs));
+		return;
+	}
+
+	if (typeof provider.await_convergence === "function") {
+		try {
+			await provider.await_convergence(scope, ingestedIds, convergenceWaitMs);
+			return;
+		} catch {
+			// Fall through to sleep
+		}
+	}
+
+	await new Promise((resolve) => setTimeout(resolve, convergenceWaitMs));
+}

--- a/benchmarks/CRUD-semantics/utils.ts
+++ b/benchmarks/CRUD-semantics/utils.ts
@@ -115,7 +115,7 @@ export async function getConvergenceWaitMs(
  * @param provider - The memory provider
  * @param scope - Execution context for the operation
  * @param ingestedIds - IDs of recently written records
- * @param waitMs - Override wait time (uses provider capabilities if 0)
+ * @param waitMs - Override wait time in ms (omit to use provider capabilities; pass 0 to skip waiting)
  */
 export async function waitForConvergence(
 	provider: BaseProvider,

--- a/tests/benchmark/crud-semantics.test.ts
+++ b/tests/benchmark/crud-semantics.test.ts
@@ -1,0 +1,171 @@
+/**
+ * CRUD Semantics Benchmark - Live Integration Test
+ *
+ * Tests the benchmark against LocalBaseline provider with real execution.
+ * Gated by RUN_LIVE_TESTS=1 environment variable.
+ *
+ * @see specs/014-crud-semantics-benchmark/tasks.md T022-T023
+ */
+
+import { describe, expect, test, beforeAll } from "bun:test";
+import crudBenchmark from "../../benchmarks/CRUD-semantics/index";
+import type { ScopeContext } from "../../types/core";
+import type { BaseProvider } from "../../types/provider";
+
+// Skip all tests if RUN_LIVE_TESTS is not set
+const LIVE_TESTS_ENABLED = process.env.RUN_LIVE_TESTS === "1";
+
+describe.skipIf(!LIVE_TESTS_ENABLED)("CRUD Semantics Benchmark - Live Integration", () => {
+	let provider: BaseProvider;
+	let scope: ScopeContext;
+
+	beforeAll(async () => {
+		// Import LocalBaseline provider dynamically
+		const providerModule = await import("../../providers/LocalBaseline/index");
+		provider = providerModule.default;
+
+		// Create a unique scope for test isolation
+		scope = {
+			user_id: `test_user_${Date.now()}`,
+			run_id: `test_run_crud_${Date.now()}`,
+			session_id: `test_session_${Date.now()}`,
+		};
+	});
+
+	test("benchmark meta has correct properties", () => {
+		expect(crudBenchmark.meta.name).toBe("CRUD-semantics");
+		expect(crudBenchmark.meta.version).toBe("1.0.0");
+		expect(crudBenchmark.meta.required_capabilities).toContain("add_memory");
+		expect(crudBenchmark.meta.required_capabilities).toContain("retrieve_memory");
+		expect(crudBenchmark.meta.required_capabilities).toContain("delete_memory");
+	});
+
+	test("cases() returns all expected case types", () => {
+		const cases = Array.from(crudBenchmark.cases());
+
+		// Should have write_retrieve cases
+		const writeRetrieveCases = cases.filter((c) => c.id.startsWith("write_retrieve"));
+		expect(writeRetrieveCases.length).toBeGreaterThan(0);
+
+		// Should have delete_leakage cases
+		const deleteLeakageCases = cases.filter((c) => c.id.startsWith("delete_leakage"));
+		expect(deleteLeakageCases.length).toBeGreaterThan(0);
+
+		// Should have update_staleness cases
+		const updateStalenessCases = cases.filter((c) => c.id.startsWith("update_staleness"));
+		expect(updateStalenessCases.length).toBeGreaterThan(0);
+	});
+
+	test("write_retrieve case passes with LocalBaseline", async () => {
+		const cases = Array.from(crudBenchmark.cases());
+		const writeRetrieveCase = cases.find((c) => c.id === "write_retrieve_01");
+		expect(writeRetrieveCase).toBeDefined();
+
+		const result = await crudBenchmark.run_case(provider, scope, writeRetrieveCase!);
+
+		expect(result.case_id).toBe("write_retrieve_01");
+		expect(result.status).toBe("pass");
+		expect(result.scores.write_retrieve_success).toBe(1);
+		expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+		expect(result.scores.add_latency_ms).toBeGreaterThanOrEqual(0);
+		expect(result.scores.retrieve_latency_ms).toBeGreaterThanOrEqual(0);
+	});
+
+	test("delete_leakage case passes with LocalBaseline", async () => {
+		const cases = Array.from(crudBenchmark.cases());
+		const deleteLeakageCase = cases.find((c) => c.id === "delete_leakage_01");
+		expect(deleteLeakageCase).toBeDefined();
+
+		const result = await crudBenchmark.run_case(provider, scope, deleteLeakageCase!);
+
+		expect(result.case_id).toBe("delete_leakage_01");
+		expect(result.status).toBe("pass");
+		expect(result.scores.delete_leakage_count).toBe(0);
+		expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+		expect(result.scores.delete_latency_ms).toBeGreaterThanOrEqual(0);
+	});
+
+	test("update_staleness case skips when provider lacks update_memory", async () => {
+		const cases = Array.from(crudBenchmark.cases());
+		const updateStalenessCase = cases.find((c) => c.id === "update_staleness_01");
+		expect(updateStalenessCase).toBeDefined();
+
+		const result = await crudBenchmark.run_case(provider, scope, updateStalenessCase!);
+
+		expect(result.case_id).toBe("update_staleness_01");
+		// LocalBaseline doesn't support update_memory, so it should skip
+		expect(result.status).toBe("skip");
+	});
+
+	test("all cases execute without errors", async () => {
+		const cases = Array.from(crudBenchmark.cases());
+
+		for (const benchmarkCase of cases) {
+			const result = await crudBenchmark.run_case(provider, scope, benchmarkCase);
+
+			// No errors should occur
+			expect(result.status).not.toBe("error");
+
+			// Duration should be tracked
+			expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+
+			// Scores should be an object
+			expect(typeof result.scores).toBe("object");
+		}
+	});
+
+	test("metrics contain expected fields for write_retrieve", async () => {
+		const cases = Array.from(crudBenchmark.cases());
+		const writeRetrieveCase = cases.find((c) => c.id === "write_retrieve_01");
+
+		const result = await crudBenchmark.run_case(provider, scope, writeRetrieveCase!);
+
+		// Check all expected metric fields exist
+		expect(result.scores).toHaveProperty("write_retrieve_success");
+		expect(result.scores).toHaveProperty("staleness_violation_count");
+		expect(result.scores).toHaveProperty("delete_leakage_count");
+		expect(result.scores).toHaveProperty("add_latency_ms");
+		expect(result.scores).toHaveProperty("retrieve_latency_ms");
+		expect(result.scores).toHaveProperty("update_latency_ms");
+		expect(result.scores).toHaveProperty("delete_latency_ms");
+	});
+
+	test("metrics contain expected fields for delete_leakage", async () => {
+		const cases = Array.from(crudBenchmark.cases());
+		const deleteLeakageCase = cases.find((c) => c.id === "delete_leakage_01");
+
+		const result = await crudBenchmark.run_case(provider, scope, deleteLeakageCase!);
+
+		// Check metric values are correct types
+		expect(typeof result.scores.delete_leakage_count).toBe("number");
+		expect(typeof result.scores.add_latency_ms).toBe("number");
+		expect(typeof result.scores.delete_latency_ms).toBe("number");
+		expect(typeof result.scores.retrieve_latency_ms).toBe("number");
+	});
+});
+
+// Non-gated tests that can run without RUN_LIVE_TESTS
+describe("CRUD Semantics Benchmark - Unit Tests", () => {
+	test("benchmark exports correctly", () => {
+		expect(crudBenchmark).toBeDefined();
+		expect(crudBenchmark.meta).toBeDefined();
+		expect(crudBenchmark.cases).toBeDefined();
+		expect(crudBenchmark.run_case).toBeDefined();
+	});
+
+	test("cases() is iterable", () => {
+		const cases = crudBenchmark.cases();
+		expect(typeof cases[Symbol.iterator]).toBe("function");
+	});
+
+	test("all cases have required fields", () => {
+		const cases = Array.from(crudBenchmark.cases());
+
+		for (const benchmarkCase of cases) {
+			expect(benchmarkCase.id).toBeDefined();
+			expect(typeof benchmarkCase.id).toBe("string");
+			expect(benchmarkCase.input).toBeDefined();
+			expect(typeof benchmarkCase.input).toBe("object");
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Implements a new benchmark that evaluates memory provider lifecycle semantics:

- **Write/Retrieve**: Verify stored content is retrievable using unique token matching
- **Update Staleness**: Verify old values don't persist after updates (capability-gated)
- **Delete Leakage**: Verify deleted content doesn't leak through adversarial queries

### Key Features

- **Deterministic verification**: Uses unique synthetic tokens (e.g., `ULTRAVIOLET_9X7K2M`) instead of LLM-as-judge
- **Capability gating**: Gracefully skips `update_staleness` cases when provider lacks `update_memory`
- **Convergence handling**: Waits for async provider indexing before verification
- **Real-world validation**: Tested against LocalBaseline and supermemory providers

### Files Changed

- `benchmarks/CRUD-semantics/types.ts` - Core type definitions
- `benchmarks/CRUD-semantics/utils.ts` - Token detection and convergence utilities
- `benchmarks/CRUD-semantics/cases.ts` - 8 test cases (3 write_retrieve, 3 delete_leakage, 2 update_staleness)
- `benchmarks/CRUD-semantics/index.ts` - Benchmark implementation
- `tests/benchmark/crud-semantics.test.ts` - Live integration tests (gated by `RUN_LIVE_TESTS=1`)

### Metrics Tracked

- `write_retrieve_success`: 1 if token found, 0 otherwise
- `staleness_violation_count`: Count of queries returning old token after update
- `delete_leakage_count`: Count of adversarial queries leaking deleted content
- `add/retrieve/update/delete_latency_ms`: Operation timing

## Test Plan

- [x] Verify benchmark auto-discovery via `bun run index.ts list benchmarks`
- [x] Run against LocalBaseline: 6 pass, 2 skip (update cases skipped - no update_memory)
- [x] Run against supermemory: 8 pass (all cases including update_staleness)
- [x] Verify metrics appear in `metrics_summary.json`
- [x] Run live integration tests: `RUN_LIVE_TESTS=1 bun test tests/benchmark/crud-semantics.test.ts`

Closes #14