### PR TITLE
fix: replace non-null assertions with type guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ runs/
 .specify/*
 specs/**
 **.skill
+.grepai/

--- a/index.ts
+++ b/index.ts
@@ -437,9 +437,7 @@ async function handleDoctor(rawArgs: string[]): Promise<void> {
 	if (!providerName) {
 		const providerNames = await getProviderNamesForHelp();
 		throw new Error(
-			`No provider specified.\n\n` +
-				`Usage: bun run index.ts doctor --provider <name> [--json]\n\n` +
-				`Available providers: ${providerNames}`,
+			`No provider specified.\n\nUsage: bun run index.ts doctor --provider <name> [--json]\n\nAvailable providers: ${providerNames}`,
 		);
 	}
 

--- a/src/doctor/tests.ts
+++ b/src/doctor/tests.ts
@@ -163,9 +163,10 @@ export async function runScopeIsolationTest(
 	} catch (error) {
 		// Best-effort cleanup if memory was created before error
 		if (memoryId) {
+			const idToDelete = memoryId;
 			try {
 				await executeWithRetry(
-					() => ctx.provider.delete_memory(scopeA, memoryId!),
+					() => ctx.provider.delete_memory(scopeA, idToDelete),
 					{ base_delay_ms: 250, max_delay_ms: 2000, max_retries: 2, jitter_factor: 0.25 },
 				);
 			} catch {
@@ -436,9 +437,10 @@ export async function runDeleteLeakageTest(
 	} catch (error) {
 		// Best-effort cleanup if memory was created before error
 		if (memoryId) {
+			const idToDelete = memoryId;
 			try {
 				await executeWithRetry(
-					() => ctx.provider.delete_memory(scope, memoryId!),
+					() => ctx.provider.delete_memory(scope, idToDelete),
 					{ base_delay_ms: 250, max_delay_ms: 2000, max_retries: 2, jitter_factor: 0.25 },
 				);
 			} catch {
@@ -645,9 +647,10 @@ export async function runUpdateStalenessTest(
 	} catch (error) {
 		// Best-effort cleanup if memory was created before error
 		if (memoryId) {
+			const idToDelete = memoryId;
 			try {
 				await executeWithRetry(
-					() => ctx.provider.delete_memory(scope, memoryId!),
+					() => ctx.provider.delete_memory(scope, idToDelete),
 					{ base_delay_ms: 250, max_delay_ms: 2000, max_retries: 2, jitter_factor: 0.25 },
 				);
 			} catch {

--- a/tests/benchmark/crud-semantics.test.ts
+++ b/tests/benchmark/crud-semantics.test.ts
@@ -59,9 +59,9 @@ describe.skipIf(!LIVE_TESTS_ENABLED)("CRUD Semantics Benchmark - Live Integratio
 	test("write_retrieve case passes with LocalBaseline", async () => {
 		const cases = Array.from(crudBenchmark.cases());
 		const writeRetrieveCase = cases.find((c) => c.id === "write_retrieve_01");
-		expect(writeRetrieveCase).toBeDefined();
+		if (!writeRetrieveCase) throw new Error("write_retrieve_01 case not found");
 
-		const result = await crudBenchmark.run_case(provider, scope, writeRetrieveCase!);
+		const result = await crudBenchmark.run_case(provider, scope, writeRetrieveCase);
 
 		expect(result.case_id).toBe("write_retrieve_01");
 		expect(result.status).toBe("pass");
@@ -74,9 +74,9 @@ describe.skipIf(!LIVE_TESTS_ENABLED)("CRUD Semantics Benchmark - Live Integratio
 	test("delete_leakage case passes with LocalBaseline", async () => {
 		const cases = Array.from(crudBenchmark.cases());
 		const deleteLeakageCase = cases.find((c) => c.id === "delete_leakage_01");
-		expect(deleteLeakageCase).toBeDefined();
+		if (!deleteLeakageCase) throw new Error("delete_leakage_01 case not found");
 
-		const result = await crudBenchmark.run_case(provider, scope, deleteLeakageCase!);
+		const result = await crudBenchmark.run_case(provider, scope, deleteLeakageCase);
 
 		expect(result.case_id).toBe("delete_leakage_01");
 		expect(result.status).toBe("pass");
@@ -88,9 +88,9 @@ describe.skipIf(!LIVE_TESTS_ENABLED)("CRUD Semantics Benchmark - Live Integratio
 	test("update_staleness case skips when provider lacks update_memory", async () => {
 		const cases = Array.from(crudBenchmark.cases());
 		const updateStalenessCase = cases.find((c) => c.id === "update_staleness_01");
-		expect(updateStalenessCase).toBeDefined();
+		if (!updateStalenessCase) throw new Error("update_staleness_01 case not found");
 
-		const result = await crudBenchmark.run_case(provider, scope, updateStalenessCase!);
+		const result = await crudBenchmark.run_case(provider, scope, updateStalenessCase);
 
 		expect(result.case_id).toBe("update_staleness_01");
 		// LocalBaseline doesn't support update_memory, so it should skip
@@ -117,8 +117,9 @@ describe.skipIf(!LIVE_TESTS_ENABLED)("CRUD Semantics Benchmark - Live Integratio
 	test("metrics contain expected fields for write_retrieve", async () => {
 		const cases = Array.from(crudBenchmark.cases());
 		const writeRetrieveCase = cases.find((c) => c.id === "write_retrieve_01");
+		if (!writeRetrieveCase) throw new Error("write_retrieve_01 case not found");
 
-		const result = await crudBenchmark.run_case(provider, scope, writeRetrieveCase!);
+		const result = await crudBenchmark.run_case(provider, scope, writeRetrieveCase);
 
 		// Check all expected metric fields exist
 		expect(result.scores).toHaveProperty("write_retrieve_success");
@@ -133,8 +134,9 @@ describe.skipIf(!LIVE_TESTS_ENABLED)("CRUD Semantics Benchmark - Live Integratio
 	test("metrics contain expected fields for delete_leakage", async () => {
 		const cases = Array.from(crudBenchmark.cases());
 		const deleteLeakageCase = cases.find((c) => c.id === "delete_leakage_01");
+		if (!deleteLeakageCase) throw new Error("delete_leakage_01 case not found");
 
-		const result = await crudBenchmark.run_case(provider, scope, deleteLeakageCase!);
+		const result = await crudBenchmark.run_case(provider, scope, deleteLeakageCase);
 
 		// Check metric values are correct types
 		expect(typeof result.scores.delete_leakage_count).toBe("number");


### PR DESCRIPTION
## Summary
- Removes type escape hatches (`!`) in favor of proper TypeScript patterns
- Uses type guards and early throws to prove properties exist at compile time
- Improves code maintainability by making type narrowing explicit

## Changes
- `src/doctor/tests.ts`: Capture `memoryId` in const before closure to avoid non-null assertion
- `tests/benchmark/crud-semantics.test.ts`: Use early throws instead of `expect().toBeDefined()` followed by non-null assertion
- `index.ts`: String formatting cleanup
- `.gitignore`: Add `.grepai/` to ignored patterns

## Test plan
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun test` passes