### PR TITLE
chore: add lint/format scripts and apply formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
 		"@types/bun": "latest"
 	},
 	"scripts": {
+		"lint": "biome lint src providers types index.ts tests",
+		"lint:all": "biome lint .",
+		"format": "biome format --write src providers types index.ts tests",
+		"format:check": "biome format src providers types index.ts tests",
 		"check": "biome check src providers types index.ts tests",
 		"check:all": "biome check .",
 		"typecheck": "tsc --noEmit -p tsconfig.core.json",

--- a/src/doctor/tests.ts
+++ b/src/doctor/tests.ts
@@ -96,7 +96,12 @@ export async function runScopeIsolationTest(
 			try {
 				await executeWithRetry(
 					() => ctx.provider.delete_memory(scopeA, memory.id),
-					{ base_delay_ms: 250, max_delay_ms: 2000, max_retries: 2, jitter_factor: 0.25 },
+					{
+						base_delay_ms: 250,
+						max_delay_ms: 2000,
+						max_retries: 2,
+						jitter_factor: 0.25,
+					},
 				);
 			} catch {
 				// Ignore cleanup errors
@@ -105,7 +110,8 @@ export async function runScopeIsolationTest(
 			return {
 				test_name: "scope_isolation",
 				status: "error",
-				message: "Could not verify token visibility in scope A - test inconclusive",
+				message:
+					"Could not verify token visibility in scope A - test inconclusive",
 				duration_ms: Date.now() - startTime,
 				details: { token, reason: "token_not_visible_in_scope_a" },
 			};
@@ -167,7 +173,12 @@ export async function runScopeIsolationTest(
 			try {
 				await executeWithRetry(
 					() => ctx.provider.delete_memory(scopeA, idToDelete),
-					{ base_delay_ms: 250, max_delay_ms: 2000, max_retries: 2, jitter_factor: 0.25 },
+					{
+						base_delay_ms: 250,
+						max_delay_ms: 2000,
+						max_retries: 2,
+						jitter_factor: 0.25,
+					},
 				);
 			} catch {
 				// Ignore cleanup errors
@@ -380,7 +391,12 @@ export async function runDeleteLeakageTest(
 			try {
 				await executeWithRetry(
 					() => ctx.provider.delete_memory(scope, memory.id),
-					{ base_delay_ms: 250, max_delay_ms: 2000, max_retries: 2, jitter_factor: 0.25 },
+					{
+						base_delay_ms: 250,
+						max_delay_ms: 2000,
+						max_retries: 2,
+						jitter_factor: 0.25,
+					},
 				);
 			} catch {
 				// Ignore cleanup errors
@@ -393,7 +409,11 @@ export async function runDeleteLeakageTest(
 				message:
 					"Could not verify token visibility before delete - test inconclusive",
 				duration_ms: Date.now() - startTime,
-				details: { token, memory_id: memory.id, reason: "token_not_visible_before_delete" },
+				details: {
+					token,
+					memory_id: memory.id,
+					reason: "token_not_visible_before_delete",
+				},
 			};
 		}
 
@@ -441,7 +461,12 @@ export async function runDeleteLeakageTest(
 			try {
 				await executeWithRetry(
 					() => ctx.provider.delete_memory(scope, idToDelete),
-					{ base_delay_ms: 250, max_delay_ms: 2000, max_retries: 2, jitter_factor: 0.25 },
+					{
+						base_delay_ms: 250,
+						max_delay_ms: 2000,
+						max_retries: 2,
+						jitter_factor: 0.25,
+					},
 				);
 			} catch {
 				// Ignore cleanup errors
@@ -651,7 +676,12 @@ export async function runUpdateStalenessTest(
 			try {
 				await executeWithRetry(
 					() => ctx.provider.delete_memory(scope, idToDelete),
-					{ base_delay_ms: 250, max_delay_ms: 2000, max_retries: 2, jitter_factor: 0.25 },
+					{
+						base_delay_ms: 250,
+						max_delay_ms: 2000,
+						max_retries: 2,
+						jitter_factor: 0.25,
+					},
 				);
 			} catch {
 				// Ignore cleanup errors

--- a/tests/benchmark/crud-semantics.test.ts
+++ b/tests/benchmark/crud-semantics.test.ts
@@ -15,136 +15,182 @@ import type { BaseProvider } from "../../types/provider";
 // Skip all tests if RUN_LIVE_TESTS is not set
 const LIVE_TESTS_ENABLED = process.env.RUN_LIVE_TESTS === "1";
 
-describe.skipIf(!LIVE_TESTS_ENABLED)("CRUD Semantics Benchmark - Live Integration", () => {
-	let provider: BaseProvider;
-	let scope: ScopeContext;
+describe.skipIf(!LIVE_TESTS_ENABLED)(
+	"CRUD Semantics Benchmark - Live Integration",
+	() => {
+		let provider: BaseProvider;
+		let scope: ScopeContext;
 
-	beforeAll(async () => {
-		// Import LocalBaseline provider dynamically
-		const providerModule = await import("../../providers/LocalBaseline/index");
-		provider = providerModule.default;
+		beforeAll(async () => {
+			// Import LocalBaseline provider dynamically
+			const providerModule = await import(
+				"../../providers/LocalBaseline/index"
+			);
+			provider = providerModule.default;
 
-		// Create a unique scope for test isolation
-		scope = {
-			user_id: `test_user_${Date.now()}`,
-			run_id: `test_run_crud_${Date.now()}`,
-			session_id: `test_session_${Date.now()}`,
-		};
-	});
+			// Create a unique scope for test isolation
+			scope = {
+				user_id: `test_user_${Date.now()}`,
+				run_id: `test_run_crud_${Date.now()}`,
+				session_id: `test_session_${Date.now()}`,
+			};
+		});
 
-	test("benchmark meta has correct properties", () => {
-		expect(crudBenchmark.meta.name).toBe("CRUD-semantics");
-		expect(crudBenchmark.meta.version).toBe("1.0.0");
-		expect(crudBenchmark.meta.required_capabilities).toContain("add_memory");
-		expect(crudBenchmark.meta.required_capabilities).toContain("retrieve_memory");
-		expect(crudBenchmark.meta.required_capabilities).toContain("delete_memory");
-	});
+		test("benchmark meta has correct properties", () => {
+			expect(crudBenchmark.meta.name).toBe("CRUD-semantics");
+			expect(crudBenchmark.meta.version).toBe("1.0.0");
+			expect(crudBenchmark.meta.required_capabilities).toContain("add_memory");
+			expect(crudBenchmark.meta.required_capabilities).toContain(
+				"retrieve_memory",
+			);
+			expect(crudBenchmark.meta.required_capabilities).toContain(
+				"delete_memory",
+			);
+		});
 
-	test("cases() returns all expected case types", () => {
-		const cases = Array.from(crudBenchmark.cases());
+		test("cases() returns all expected case types", () => {
+			const cases = Array.from(crudBenchmark.cases());
 
-		// Should have write_retrieve cases
-		const writeRetrieveCases = cases.filter((c) => c.id.startsWith("write_retrieve"));
-		expect(writeRetrieveCases.length).toBeGreaterThan(0);
+			// Should have write_retrieve cases
+			const writeRetrieveCases = cases.filter((c) =>
+				c.id.startsWith("write_retrieve"),
+			);
+			expect(writeRetrieveCases.length).toBeGreaterThan(0);
 
-		// Should have delete_leakage cases
-		const deleteLeakageCases = cases.filter((c) => c.id.startsWith("delete_leakage"));
-		expect(deleteLeakageCases.length).toBeGreaterThan(0);
+			// Should have delete_leakage cases
+			const deleteLeakageCases = cases.filter((c) =>
+				c.id.startsWith("delete_leakage"),
+			);
+			expect(deleteLeakageCases.length).toBeGreaterThan(0);
 
-		// Should have update_staleness cases
-		const updateStalenessCases = cases.filter((c) => c.id.startsWith("update_staleness"));
-		expect(updateStalenessCases.length).toBeGreaterThan(0);
-	});
+			// Should have update_staleness cases
+			const updateStalenessCases = cases.filter((c) =>
+				c.id.startsWith("update_staleness"),
+			);
+			expect(updateStalenessCases.length).toBeGreaterThan(0);
+		});
 
-	test("write_retrieve case passes with LocalBaseline", async () => {
-		const cases = Array.from(crudBenchmark.cases());
-		const writeRetrieveCase = cases.find((c) => c.id === "write_retrieve_01");
-		if (!writeRetrieveCase) throw new Error("write_retrieve_01 case not found");
+		test("write_retrieve case passes with LocalBaseline", async () => {
+			const cases = Array.from(crudBenchmark.cases());
+			const writeRetrieveCase = cases.find((c) => c.id === "write_retrieve_01");
+			if (!writeRetrieveCase)
+				throw new Error("write_retrieve_01 case not found");
 
-		const result = await crudBenchmark.run_case(provider, scope, writeRetrieveCase);
+			const result = await crudBenchmark.run_case(
+				provider,
+				scope,
+				writeRetrieveCase,
+			);
 
-		expect(result.case_id).toBe("write_retrieve_01");
-		expect(result.status).toBe("pass");
-		expect(result.scores.write_retrieve_success).toBe(1);
-		expect(result.duration_ms).toBeGreaterThanOrEqual(0);
-		expect(result.scores.add_latency_ms).toBeGreaterThanOrEqual(0);
-		expect(result.scores.retrieve_latency_ms).toBeGreaterThanOrEqual(0);
-	});
-
-	test("delete_leakage case passes with LocalBaseline", async () => {
-		const cases = Array.from(crudBenchmark.cases());
-		const deleteLeakageCase = cases.find((c) => c.id === "delete_leakage_01");
-		if (!deleteLeakageCase) throw new Error("delete_leakage_01 case not found");
-
-		const result = await crudBenchmark.run_case(provider, scope, deleteLeakageCase);
-
-		expect(result.case_id).toBe("delete_leakage_01");
-		expect(result.status).toBe("pass");
-		expect(result.scores.delete_leakage_count).toBe(0);
-		expect(result.duration_ms).toBeGreaterThanOrEqual(0);
-		expect(result.scores.delete_latency_ms).toBeGreaterThanOrEqual(0);
-	});
-
-	test("update_staleness case skips when provider lacks update_memory", async () => {
-		const cases = Array.from(crudBenchmark.cases());
-		const updateStalenessCase = cases.find((c) => c.id === "update_staleness_01");
-		if (!updateStalenessCase) throw new Error("update_staleness_01 case not found");
-
-		const result = await crudBenchmark.run_case(provider, scope, updateStalenessCase);
-
-		expect(result.case_id).toBe("update_staleness_01");
-		// LocalBaseline doesn't support update_memory, so it should skip
-		expect(result.status).toBe("skip");
-	});
-
-	test("all cases execute without errors", async () => {
-		const cases = Array.from(crudBenchmark.cases());
-
-		for (const benchmarkCase of cases) {
-			const result = await crudBenchmark.run_case(provider, scope, benchmarkCase);
-
-			// No errors should occur
-			expect(result.status).not.toBe("error");
-
-			// Duration should be tracked
+			expect(result.case_id).toBe("write_retrieve_01");
+			expect(result.status).toBe("pass");
+			expect(result.scores.write_retrieve_success).toBe(1);
 			expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+			expect(result.scores.add_latency_ms).toBeGreaterThanOrEqual(0);
+			expect(result.scores.retrieve_latency_ms).toBeGreaterThanOrEqual(0);
+		});
 
-			// Scores should be an object
-			expect(typeof result.scores).toBe("object");
-		}
-	});
+		test("delete_leakage case passes with LocalBaseline", async () => {
+			const cases = Array.from(crudBenchmark.cases());
+			const deleteLeakageCase = cases.find((c) => c.id === "delete_leakage_01");
+			if (!deleteLeakageCase)
+				throw new Error("delete_leakage_01 case not found");
 
-	test("metrics contain expected fields for write_retrieve", async () => {
-		const cases = Array.from(crudBenchmark.cases());
-		const writeRetrieveCase = cases.find((c) => c.id === "write_retrieve_01");
-		if (!writeRetrieveCase) throw new Error("write_retrieve_01 case not found");
+			const result = await crudBenchmark.run_case(
+				provider,
+				scope,
+				deleteLeakageCase,
+			);
 
-		const result = await crudBenchmark.run_case(provider, scope, writeRetrieveCase);
+			expect(result.case_id).toBe("delete_leakage_01");
+			expect(result.status).toBe("pass");
+			expect(result.scores.delete_leakage_count).toBe(0);
+			expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+			expect(result.scores.delete_latency_ms).toBeGreaterThanOrEqual(0);
+		});
 
-		// Check all expected metric fields exist
-		expect(result.scores).toHaveProperty("write_retrieve_success");
-		expect(result.scores).toHaveProperty("staleness_violation_count");
-		expect(result.scores).toHaveProperty("delete_leakage_count");
-		expect(result.scores).toHaveProperty("add_latency_ms");
-		expect(result.scores).toHaveProperty("retrieve_latency_ms");
-		expect(result.scores).toHaveProperty("update_latency_ms");
-		expect(result.scores).toHaveProperty("delete_latency_ms");
-	});
+		test("update_staleness case skips when provider lacks update_memory", async () => {
+			const cases = Array.from(crudBenchmark.cases());
+			const updateStalenessCase = cases.find(
+				(c) => c.id === "update_staleness_01",
+			);
+			if (!updateStalenessCase)
+				throw new Error("update_staleness_01 case not found");
 
-	test("metrics contain expected fields for delete_leakage", async () => {
-		const cases = Array.from(crudBenchmark.cases());
-		const deleteLeakageCase = cases.find((c) => c.id === "delete_leakage_01");
-		if (!deleteLeakageCase) throw new Error("delete_leakage_01 case not found");
+			const result = await crudBenchmark.run_case(
+				provider,
+				scope,
+				updateStalenessCase,
+			);
 
-		const result = await crudBenchmark.run_case(provider, scope, deleteLeakageCase);
+			expect(result.case_id).toBe("update_staleness_01");
+			// LocalBaseline doesn't support update_memory, so it should skip
+			expect(result.status).toBe("skip");
+		});
 
-		// Check metric values are correct types
-		expect(typeof result.scores.delete_leakage_count).toBe("number");
-		expect(typeof result.scores.add_latency_ms).toBe("number");
-		expect(typeof result.scores.delete_latency_ms).toBe("number");
-		expect(typeof result.scores.retrieve_latency_ms).toBe("number");
-	});
-});
+		test("all cases execute without errors", async () => {
+			const cases = Array.from(crudBenchmark.cases());
+
+			for (const benchmarkCase of cases) {
+				const result = await crudBenchmark.run_case(
+					provider,
+					scope,
+					benchmarkCase,
+				);
+
+				// No errors should occur
+				expect(result.status).not.toBe("error");
+
+				// Duration should be tracked
+				expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+
+				// Scores should be an object
+				expect(typeof result.scores).toBe("object");
+			}
+		});
+
+		test("metrics contain expected fields for write_retrieve", async () => {
+			const cases = Array.from(crudBenchmark.cases());
+			const writeRetrieveCase = cases.find((c) => c.id === "write_retrieve_01");
+			if (!writeRetrieveCase)
+				throw new Error("write_retrieve_01 case not found");
+
+			const result = await crudBenchmark.run_case(
+				provider,
+				scope,
+				writeRetrieveCase,
+			);
+
+			// Check all expected metric fields exist
+			expect(result.scores).toHaveProperty("write_retrieve_success");
+			expect(result.scores).toHaveProperty("staleness_violation_count");
+			expect(result.scores).toHaveProperty("delete_leakage_count");
+			expect(result.scores).toHaveProperty("add_latency_ms");
+			expect(result.scores).toHaveProperty("retrieve_latency_ms");
+			expect(result.scores).toHaveProperty("update_latency_ms");
+			expect(result.scores).toHaveProperty("delete_latency_ms");
+		});
+
+		test("metrics contain expected fields for delete_leakage", async () => {
+			const cases = Array.from(crudBenchmark.cases());
+			const deleteLeakageCase = cases.find((c) => c.id === "delete_leakage_01");
+			if (!deleteLeakageCase)
+				throw new Error("delete_leakage_01 case not found");
+
+			const result = await crudBenchmark.run_case(
+				provider,
+				scope,
+				deleteLeakageCase,
+			);
+
+			// Check metric values are correct types
+			expect(typeof result.scores.delete_leakage_count).toBe("number");
+			expect(typeof result.scores.add_latency_ms).toBe("number");
+			expect(typeof result.scores.delete_latency_ms).toBe("number");
+			expect(typeof result.scores.retrieve_latency_ms).toBe("number");
+		});
+	},
+);
 
 // Non-gated tests that can run without RUN_LIVE_TESTS
 describe("CRUD Semantics Benchmark - Unit Tests", () => {

--- a/tests/integration/doctor.test.ts
+++ b/tests/integration/doctor.test.ts
@@ -56,10 +56,18 @@ describe("Doctor Command - Live Integration Tests", () => {
 
 		// LocalBaseline should pass scope_isolation, visibility_delay, delete_leakage
 		// LocalBaseline should skip update_staleness (doesn't support update_memory)
-		const scopeTest = report.tests.find((t) => t.test_name === "scope_isolation");
-		const visibilityTest = report.tests.find((t) => t.test_name === "visibility_delay");
-		const deleteTest = report.tests.find((t) => t.test_name === "delete_leakage");
-		const updateTest = report.tests.find((t) => t.test_name === "update_staleness");
+		const scopeTest = report.tests.find(
+			(t) => t.test_name === "scope_isolation",
+		);
+		const visibilityTest = report.tests.find(
+			(t) => t.test_name === "visibility_delay",
+		);
+		const deleteTest = report.tests.find(
+			(t) => t.test_name === "delete_leakage",
+		);
+		const updateTest = report.tests.find(
+			(t) => t.test_name === "update_staleness",
+		);
 
 		expect(scopeTest?.status).toBe("pass");
 		expect(visibilityTest?.status).toBe("pass");
@@ -107,7 +115,9 @@ describe("Doctor Command - Live Integration Tests", () => {
 			json_output: false,
 		});
 
-		const visibilityTest = report.tests.find((t) => t.test_name === "visibility_delay");
+		const visibilityTest = report.tests.find(
+			(t) => t.test_name === "visibility_delay",
+		);
 		expect(visibilityTest).toBeDefined();
 		expect(visibilityTest?.status).toBe("pass");
 
@@ -144,7 +154,9 @@ describe("Doctor Command - Live Integration Tests", () => {
 			json_output: false,
 		});
 
-		const scopeTest = report.tests.find((t) => t.test_name === "scope_isolation");
+		const scopeTest = report.tests.find(
+			(t) => t.test_name === "scope_isolation",
+		);
 		expect(scopeTest).toBeDefined();
 		expect(scopeTest?.status).toBe("pass");
 		expect(scopeTest?.message).toContain("not retrievable from scope B");
@@ -171,7 +183,9 @@ describe("Doctor Command - Live Integration Tests", () => {
 			json_output: false,
 		});
 
-		const deleteTest = report.tests.find((t) => t.test_name === "delete_leakage");
+		const deleteTest = report.tests.find(
+			(t) => t.test_name === "delete_leakage",
+		);
 		expect(deleteTest).toBeDefined();
 		expect(deleteTest?.status).toBe("pass");
 		expect(deleteTest?.message).toContain("not retrievable");
@@ -197,7 +211,9 @@ describe("Doctor Command - Live Integration Tests", () => {
 			json_output: false,
 		});
 
-		const updateTest = report.tests.find((t) => t.test_name === "update_staleness");
+		const updateTest = report.tests.find(
+			(t) => t.test_name === "update_staleness",
+		);
 		expect(updateTest).toBeDefined();
 		expect(updateTest?.status).toBe("skip");
 		expect(updateTest?.message).toContain("update_memory not supported");


### PR DESCRIPTION
## Summary
This PR brings the remaining changes from PR #40 into main.

### Changes
- Added `lint`, `lint:all`, `format`, `format:check` scripts to package.json
- Applied biome formatting fixes to test files

### Background
PR #40 was accidentally merged into `feat/019-type-safety-cleanup` instead of main. This PR brings those changes to main.

## Test plan
- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run typecheck` passes