### PR TITLE
chore: add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# Restrict GITHUB_TOKEN permissions to minimum required
+permissions:
+  contents: read
+
 jobs:
   lint-typecheck-test:
     runs-on: ubuntu-latest
@@ -17,7 +21,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.1.42"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-typecheck-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run lint
+        run: bun run lint
+
+      - name: Run typecheck
+        run: bun run typecheck
+
+      - name: Run tests
+        run: bun test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.1.42"
+          bun-version: "1.2.0"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary
Adds a GitHub Actions CI workflow to automate quality checks on pushes and PRs.

## Pipeline Steps
1. **Checkout** - Clone repository
2. **Setup Bun** - Install latest Bun runtime
3. **Install** - Run `bun install --frozen-lockfile`
4. **Lint** - Run `bun run lint` (biome lint)
5. **Typecheck** - Run `bun run typecheck` (tsc --noEmit)
6. **Test** - Run `bun test`

## Triggers
- Push to `main` branch
- Pull requests targeting `main`

## Dependencies
This PR requires PR #41 (lint/format scripts) to be merged first, as the CI workflow uses `bun run lint`.

## Test plan
- [x] Workflow file syntax is valid YAML
- [x] Uses standard GitHub Actions (actions/checkout@v4, oven-sh/setup-bun@v2)
- [ ] Will be validated when CI runs after merge